### PR TITLE
added permission checks for accessing profile views

### DIFF
--- a/deployment/demo.env
+++ b/deployment/demo.env
@@ -31,6 +31,6 @@ DJANGO_DATABASE_URL="postgis://user:password@localhost:5432/save-my-bike"
 DJANGO_PUBLIC_URL="http://localhost:8000"
 KEYCLOAK_BASE_URL="http://localhost:8080"
 KEYCLOAK_REALM=save-my-bike
-DJANGO_KEYCLOAK_CLIENT_ID=smbportal
+DJANGO_KEYCLOAK_CLIENT_ID=smb-portal
 KEYCLOAK_ADMIN_USERNAME=admin
 KEYCLOAK_ADMIN_PASSWORD=ttt

--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     "profiles.apps.ProfilesConfig",
     "vehicles.apps.VehiclesConfig",
     "tracks.apps.TracksConfig",
+    "rules.apps.AutodiscoverRulesConfig",
 ]
 
 MIDDLEWARE = [

--- a/smbportal/base/settings/dev.py
+++ b/smbportal/base/settings/dev.py
@@ -39,7 +39,8 @@ LOGGING = {
         },
         'djangooidc': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'ERROR',
+            'propagate': False,
         },
         'profiles': {
             'handlers': ['console'],

--- a/smbportal/profiles/models.py
+++ b/smbportal/profiles/models.py
@@ -11,8 +11,6 @@
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
-from django.urls import reverse
-from django.utils.text import slugify
 
 
 # TODO: Integrate with django-avatar for avatar support
@@ -49,7 +47,19 @@ class SmbUser(AbstractUser):
 
     @property
     def profile(self):
-        return self.enduserprofile
+        attibute_names = (
+            "enduserprofile",
+            # add more profiles for analysts, prize managers, etc
+        )
+        for attr in attibute_names:
+            try:
+                profile = getattr(self, attr)
+                break
+            except AttributeError:
+                pass
+        else:
+            profile = None
+        return profile
 
 
 # TODO: Integrate data sharing policies

--- a/smbportal/profiles/rules.py
+++ b/smbportal/profiles/rules.py
@@ -1,0 +1,43 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+"""Permissions for accessing profile related resources and info
+
+These permissions are kept in memory, they do not need to be stored in the db
+
+"""
+
+import logging
+
+import rules
+
+logger = logging.getLogger(__name__)
+
+
+@rules.predicate
+def is_owner(user, obj):
+    return obj.owner == user
+
+
+@rules.predicate
+def is_profile_owner(user, profile_obj):
+    return user.profile == profile_obj if user.is_authenticated else False
+
+
+@rules.predicate
+def has_profile(user):
+    return bool(user.profile) if user.is_authenticated else False
+
+
+is_end_user = rules.is_group_member("end_users")
+
+rules.add_perm("profiles.can_create", ~has_profile)
+rules.add_perm("profiles.can_view", has_profile & is_profile_owner)
+rules.add_perm("profiles.can_edit", has_profile & is_profile_owner)

--- a/smbportal/profiles/urls.py
+++ b/smbportal/profiles/urls.py
@@ -14,7 +14,7 @@ from . import views
 
 app_name = "profile"
 urlpatterns = [
-    path("", views.EndUserDetailView.as_view(), name="detail"),
-    path("create", views.EndUserCreateView.as_view(), name="create"),
-    path("update", views.EndUserUpdateView.as_view(), name="update"),
+    path("", views.EndUserProfileDetailView.as_view(), name="detail"),
+    path("create", views.EndUserProfileCreateView.as_view(), name="create"),
+    path("update", views.EndUserProfileUpdateView.as_view(), name="update"),
 ]

--- a/smbportal/profiles/views.py
+++ b/smbportal/profiles/views.py
@@ -8,15 +8,27 @@
 #
 #########################################################################
 
+import logging
+
+from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib import messages
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import PermissionDenied
+from django.urls import reverse_lazy
 from django.views.generic import CreateView
 from django.views.generic import DetailView
 from django.views.generic import UpdateView
 
 from . import models
+from .rules import has_profile
+from .rules import is_profile_owner
+
+logger = logging.getLogger(__name__)
 
 
-class UserActionMixin(object):
+class FormUpdatedMessageMixin(object):
 
     @property
     def success_message(self):
@@ -30,23 +42,72 @@ class UserActionMixin(object):
 class UserProfileMixin(object):
 
     def get_object(self, queryset=None):
-        return self.request.user.profile
+        user = self.request.user
+        return user.profile if has_profile(user) else False
 
 
-class EndUserDetailView(UserProfileMixin, DetailView):
+class EndUserProfileDetailView(LoginRequiredMixin, PermissionRequiredMixin,
+                               UserProfileMixin, DetailView):
     model = models.EndUserProfile
+    fields = (
+        "gender",
+    )
+    permission_required = "profiles.can_view"
+    object_level_permissions = True
+
+    def get_login_url(self):
+        if not self.request.user.is_authenticated:
+            result = settings.LOGIN_URL
+        else:
+            if not has_profile(self.request.user):
+                result = reverse_lazy("profile:create")
+            else:
+                current_profile = self.get_object()
+                if not is_profile_owner(self.request.user, current_profile):
+                    raise PermissionDenied()
+                else:
+                    raise RuntimeError()
+        return result
+
+    def has_permission(self):
+        """Test whether the current user has all required permissions
+
+        This method has been reimplemented in order to provide object-level
+        permission checks. The default django permissions implementation does
+        not check permissions on individual objects. In this case we want
+        to make sure a user can only gain access to his/her own profile.
+
+        """
+
+        current_user = self.request.user
+        try:
+            current_obj = self.request.user.profile
+        except ObjectDoesNotExist:
+            current_obj = None
+        permissions_to_check = self.get_permission_required()
+        return current_user.has_perms(permissions_to_check, obj=current_obj)
 
 
-class EndUserCreateView(UserProfileMixin, UserActionMixin, CreateView):
+class EndUserProfileCreateView(LoginRequiredMixin, PermissionRequiredMixin,
+                               UserProfileMixin, FormUpdatedMessageMixin,
+                               CreateView):
     model = models.EndUserProfile
     fields = (
         "gender",
     )
     template_name_suffix = "_create"
     success_message = "user profile created!"
+    permission_required = "profiles.can_create"
+
+    def get_login_url(self):
+        if not self.request.user.is_authenticated:
+            return settings.LOGIN_URL
+        elif has_profile(self.request.user):
+            raise PermissionDenied("User already has a profile")
 
 
-class EndUserUpdateView(UserProfileMixin, UserActionMixin, UpdateView):
+class EndUserProfileUpdateView(LoginRequiredMixin, UserProfileMixin,
+                               FormUpdatedMessageMixin, UpdateView):
     model = models.EndUserProfile
     fields = (
         "gender",


### PR DESCRIPTION
This PR adds initial permission checking for the profile views.

Views that are currently protected:

- `profiles.views.EndUserProfileDetailView`
- `profiles.views.EndUserProfileCreateView`

The profile update view (`profiles.views.EndUserProfileUpdate`) **is not covered yet**

The implemented workflow for protecting access to views is based on the django permission system.

Views use both the `login_required` and `permission_required` guards (implemented here as mixins since we are using class based views).

In order to ease the integration with keycloak, this PR is using the [django-rules](https://github.com/dfunckt/django-rules) project for defining django permissions. This allows permissions to be defined without having to store them in the DB. Most permissions are likely to be defined as a result of the user's current state (logged in, being an enduser, analyst, etc) or of the user's current roles and groups. The latter are set by keycloak and need to be updated whenever a user logs in. As such, keeping permissions outside of the django DB seems like a more flexible approach.