### PR TITLE
Added breadcrumbs support

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,6 +2,7 @@ Django==2.0
 dj-database-url==0.5.0
 django-avatar==4.1.0
 django-bootstrap4==0.0.6
+django-bootstrap-breadcrumbs==0.9.1
 django-photologue==3.8.1
 psycopg2-binary==2.7.4
 pygdal==2.2.3.3 # depends on libgdal-dev 2.3.3

--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = [
     "bootstrap4",
     "photologue",
     "sortedm2m",
+    "django_bootstrap_breadcrumbs",
     "base",
     "avatar",
     "keycloakauth.apps.KeycloakauthConfig",
@@ -193,6 +194,8 @@ STATIC_URL = "/static/"
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
 ]
+
+BREADCRUMBS_TEMPLATE = "base/breadcrumbs.html"
 
 LOGIN_URL = "/openid/openid/KeyCloak"
 

--- a/smbportal/base/templates/base/base.html
+++ b/smbportal/base/templates/base/base.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load i18n %}
 {% load avatar_tags %}
+{% load django_bootstrap_breadcrumbs %}
 <!DOCTYPE HTML>
 <html lang="en">
 <head>
@@ -222,26 +223,18 @@
 
 	    
 <!-- </section>  -->
-<div class="offcanvas-wrapper">
-{% block thickness %}
-<!-- <section class="container padding-top-3x padding-bottom-2x"> -->
-
+{% block breadcrumbs %}
+    {% clear_breadcrumbs %}
+    {% breadcrumb 'Home' 'index' %}
 {% endblock %}
+<div class="offcanvas-wrapper">
     <div class="page-title m-b-0">
         <div class="container">
             <div class="column">
                 <h1>{% block page_title %}{% endblock %}</h1>
             </div>
             <div class="column">
-                <ul class="breadcrumbs">
-                    <li>Breadcrumbs</li>
-                    <li class="separator"></li>
-                    <li>will</li>
-                    <li class="separator"></li>
-                    <li>show</li>
-                    <li class="separator"></li>
-                    <li>up here</li>
-                </ul>
+                {% render_breadcrumbs %}
             </div>
         </div>
     </div>

--- a/smbportal/base/templates/base/breadcrumbs.html
+++ b/smbportal/base/templates/base/breadcrumbs.html
@@ -1,0 +1,14 @@
+<ul class="breadcrumbs">
+    {% for url, label in breadcrumbs %}
+        <li>
+            {% ifnotequal forloop.counter breadcrumbs_total %}
+                <a href="{{ url }}">{{ label|safe }}</a>
+            {% else %}
+                {{ label|safe }}
+            {% endifnotequal %}
+        </li>
+        {% if not forloop.last %}
+            <li class="separator">&nbsp;</li>
+        {% endif %}
+    {% endfor %}
+</ul>

--- a/smbportal/profiles/templates/profiles/enduserprofile_create.html
+++ b/smbportal/profiles/templates/profiles/enduserprofile_create.html
@@ -2,29 +2,14 @@
 {% load static %}
 {% load avatar_tags %}
 {% load bootstrap4 %}
-{% block thickness %}
-    <section class="container padding-top-1x padding-bottom-2x"> </section>
-{% endblock %}
+{% load django_bootstrap_breadcrumbs %}
 
+{% block page_title %}Complete profile{% endblock %}
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% breadcrumb 'complete-profile' 'profile:create' %}
+{% endblock %}
 {% block content %}
-    <div class="page-title m-b-0">
-        <div class="container">
-            <div class="column">
-                <h1>Complete your profile</h1>
-            </div>
-            <div class="column">
-                <ul class="breadcrumbs">
-                    <li>Breadcrumbs</li>
-                    <li class="separator"></li>
-                    <li>will</li>
-                    <li class="separator"></li>
-                    <li>show</li>
-                    <li class="separator"></li>
-                    <li>up here</li>
-                </ul>
-            </div>
-        </div>
-    </div>
     <div id="container">
         <div class="container p-t-60">
             <div class="row">

--- a/smbportal/profiles/templates/profiles/enduserprofile_update.html
+++ b/smbportal/profiles/templates/profiles/enduserprofile_update.html
@@ -1,26 +1,15 @@
 {% extends 'base/base.html' %}
 {% load static %}
 {% load avatar_tags %}
+{% load bootstrap4 %}
+{% load django_bootstrap_breadcrumbs %}
 
+{% block page_title %}Your profile{% endblock %}
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% breadcrumb 'profile' 'profile:update' %}
+{% endblock %}
 {% block content %}
-    <div class="page-title m-b-0">
-        <div class="container">
-            <div class="column">
-                <h1>Your profile</h1>
-            </div>
-            <div class="column">
-                <ul class="breadcrumbs">
-                    <li>Breadcrumbs</li>
-                    <li class="separator"></li>
-                    <li>will</li>
-                    <li class="separator"></li>
-                    <li>show</li>
-                    <li class="separator"></li>
-                    <li>up here</li>
-                </ul>
-            </div>
-        </div>
-    </div>
     <div id="container">
         <div class="container p-t-60">
             <div class="row">

--- a/smbportal/vehicles/templates/vehicles/bike_confirm_delete.html
+++ b/smbportal/vehicles/templates/vehicles/bike_confirm_delete.html
@@ -1,10 +1,31 @@
 {% extends 'base/base.html' %}
+{% load bootstrap4 %}
+{% load django_bootstrap_breadcrumbs %}
+
+{% block page_title %}Delete bike{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% breadcrumb 'bikes' 'bikes:list' %}
+    {% breadcrumb bike.pk 'bikes:detail' pk=bike.pk %}
+    {% breadcrumb 'delete' 'bikes:delete' pk=bike.pk %}
+{% endblock %}
 
 {% block content %}
-    <form method="post">
-        {% csrf_token %}
-        <p>Are you sure you want to delete bike <b>{{ bike.pk }}({{ bike.nickname }})</b>?</p>
-        {{ form.as_p }}
-        <input class="btn btn-danger" type="submit" value="Confirm">
-    </form>
+    <div id="container">
+        <div class="container p-t-60">
+            <div class="row">
+                <div class="col-lg-12">
+                    <p>Are you sure you want to delete bike <b>{{ bike.pk }}({{ bike.nickname }})</b>?</p>
+                    <form method="post">
+                        {% csrf_token %}
+                        {% buttons %}
+                            <button type="submit" class="btn btn-danger btn-lg">Delete</button>
+                        {% endbuttons %}
+                    </form>
+                </div>
+            </div>
+        </div>
+
+    </div>
 {% endblock %}

--- a/smbportal/vehicles/templates/vehicles/bike_detail.html
+++ b/smbportal/vehicles/templates/vehicles/bike_detail.html
@@ -1,5 +1,13 @@
 {% extends 'base/base.html' %}
+{% load django_bootstrap_breadcrumbs %}
+
 {% block page_title %}Bike details{% endblock %}
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% breadcrumb 'bikes' 'bikes:list' %}
+    {% breadcrumb bike.pk 'bikes:detail' pk=bike.pk %}
+{% endblock %}
+
 {% block content %}
     <div id="container">
         <div class="container p-t-60">

--- a/smbportal/vehicles/templates/vehicles/bike_list.html
+++ b/smbportal/vehicles/templates/vehicles/bike_list.html
@@ -1,5 +1,11 @@
 {% extends 'base/base.html' %}
+{% load django_bootstrap_breadcrumbs %}
+
 {% block page_title %}Your bikes{% endblock %}
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% breadcrumb 'bikes' 'bikes:list' %}
+{% endblock %}
 
 {% block content %}
     <div id="container">

--- a/smbportal/vehicles/templates/vehicles/bike_picture_create.html
+++ b/smbportal/vehicles/templates/vehicles/bike_picture_create.html
@@ -1,6 +1,14 @@
 {% extends 'base/base.html' %}
 {% load i18n %}
 {% load bootstrap4 %}
+{% load django_bootstrap_breadcrumbs %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% breadcrumb 'bikes' 'bikes:list' %}
+    {% breadcrumb bike.pk 'bikes:detail' pk=bike.pk %}
+    {% breadcrumb 'add picture' 'bikes:picture-upload' pk=bike.pk %}
+{% endblock %}
 
 {% block page_title %}Add picture{% endblock %}
 {% block content %}

--- a/smbportal/vehicles/templates/vehicles/bike_update.html
+++ b/smbportal/vehicles/templates/vehicles/bike_update.html
@@ -1,14 +1,32 @@
 {% extends 'base/base.html' %}
 {% load bootstrap4 %}
+{% load django_bootstrap_breadcrumbs %}
+
+{% block page_title %}Edit bike{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% breadcrumb 'bikes' 'bikes:list' %}
+    {% breadcrumb bike.pk 'bikes:detail' pk=bike.pk %}
+    {% breadcrumb 'update' 'bikes:edit' pk=bike.pk %}
+{% endblock %}
 
 {% block content %}
-    <p>This is the bike update page for <b>{{ bike.pk }}</b></p>
-    <a href="{% url 'bikes:picture-upload' pk=bike.pk %}" class="btn btn-secondary">Upload pictures</a>
-    <form method="post" action="">
-        {% csrf_token %}
-        {% bootstrap_form form %}
-        {% buttons %}
-            <button type="submit" class="btn btn-outline-primary btn-lg">Update</button>
-        {% endbuttons %}
-    </form>
+    <div id="container">
+        <div class="container p-t-60">
+            <div class="row">
+                <div class="col-lg-12">
+                    <a href="{% url 'bikes:picture-upload' pk=bike.pk %}" class="btn btn-secondary">Upload pictures</a>
+                    <form method="post" action="">
+                        {% csrf_token %}
+                        {% bootstrap_form form %}
+                        {% buttons %}
+                            <button type="submit" class="btn btn-outline-primary btn-lg">Update bike</button>
+                        {% endbuttons %}
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
 {% endblock %}


### PR DESCRIPTION
This PR adds initial support for breadcrumbs navigation in the portal

It integrates the external [django-bootstrap-breadcumbs](https://github.com/prymitive/bootstrap-breadcrumbs) project into the portal and adds a custom breadcrumb rendering template. It also hooks most of the current templates to make use of breadcrumbs.

This PR also includes a fix for a bug that was present in #28.


#### Applying this PR

Do not forget to install django-bootstrap-breadcrumbs, as noted in the `requirements/production.txt` file 