### PR TITLE
various frontend and api tweaks

### DIFF
--- a/smbportal/api/urls.py
+++ b/smbportal/api/urls.py
@@ -22,6 +22,11 @@ from . import views
 app_name = "api"
 
 router = routers.DefaultRouter()
+# router.register(
+#     prefix=r"my-user",
+#     viewset=views.MyUserViewSet,
+#     base_name="my-user"
+# )
 router.register(
     prefix=r"my-bikes",
     viewset=views.MyBikeViewSet,
@@ -31,6 +36,11 @@ router.register(
     prefix=r"my-tags",
     viewset=views.MyPhysicalTagViewSet,
     base_name="my-tags"
+)
+router.register(
+    prefix=r"my-bike-possession-history",
+    viewset=views.MyBikePossessionHistoryViewSet,
+    base_name="my-bike-possession-history"
 )
 router.register(
     prefix=r"users",
@@ -86,9 +96,14 @@ urlpatterns = [
         name="schema-swagger-ui",
     ),
     path(
-        route=r"my-user",
-        view=views.MyUserViewSet.as_view({
-            "get": "retrieve",
-        })
+        route="my-user",
+        view=views.MyUserViewSet.as_view(
+            actions={
+                "get": "retrieve",
+                "patch": "partial_update",
+                "put": "update",
+            }
+        ),
+        name="my-user"
     )
 ] + router.urls

--- a/smbportal/base/mixins.py
+++ b/smbportal/base/mixins.py
@@ -23,7 +23,7 @@ class FormUpdatedMessageMixin(object):
 
     def form_valid(self, form):
         result = super().form_valid(form)
-        messages.info(self.request, self.success_message)
+        messages.success(self.request, self.success_message)
         return result
 
 

--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -14,6 +14,7 @@ import os
 import pathlib
 
 from django.utils.translation import ugettext_lazy as _
+from django.contrib.messages import constants as message_constants
 from django.core.exceptions import ImproperlyConfigured
 import dj_database_url
 
@@ -214,6 +215,14 @@ AVATAR_AUTO_GENERATE_SIZES = (
     80,
     150,
 )
+
+MESSAGE_TAGS = {
+    message_constants.DEBUG: "alert-info",
+    message_constants.INFO: "alert-info",
+    message_constants.SUCCESS: "alert-success",
+    message_constants.WARNING: "alert-warning",
+    message_constants.ERROR: "alert-error",
+}
 
 LOGIN_URL = "/openid/openid/KeyCloak"
 

--- a/smbportal/base/templates/base/base.html
+++ b/smbportal/base/templates/base/base.html
@@ -245,7 +245,7 @@
            <div class="row">
                <div class="col-lg">
                    {% for message in messages %}
-                       <div {% if message.tags %}class="alert alert-dismissible fade show text-center margin-bottom-1x alert-{{ message.tags }}"{% endif %}>
+                       <div {% if message.tags %}class="alert alert-dismissible fade show text-center margin-bottom-1x {{ message.tags }}"{% endif %}>
                            <span class="alert-close" data-dismiss="alert"></span>
                            {{ message }}
                        </div>

--- a/smbportal/base/templates/base/base.html
+++ b/smbportal/base/templates/base/base.html
@@ -84,7 +84,7 @@
                 <a href="{% url 'bikes:list' %}"><span>{% trans 'Bikes' %}</span></a>
             </li>
             <li>
-                <a href="javascript:void(0)"><span>{% trans 'Report a stolen Bike?' %}</span></a>
+                <a href="{% url 'bikes:report-status' %}"><span>{% trans 'Report a stolen Bike?' %}</span></a>
                 
             </li>
             <li>

--- a/smbportal/keycloakauth/permissions.py
+++ b/smbportal/keycloakauth/permissions.py
@@ -17,6 +17,26 @@ from rest_framework import permissions
 logger = logging.getLogger(__name__)
 
 
+def filter_out_unsafe_permissions(permissions_to_check):
+    unsafe_words = [
+        "create",
+        "new",
+        "edit",
+        "update",
+        "change",
+        "delete",
+        "remove",
+    ]
+    filtered = []
+    for perm in permissions_to_check:
+        for word in unsafe_words:
+            if word in perm:
+                break
+        else:
+            filtered.append(perm)
+    return filtered
+
+
 class DjangoRulesPermission(permissions.BasePermission):
 
     def _get_view_permissions(self, view):
@@ -25,24 +45,39 @@ class DjangoRulesPermission(permissions.BasePermission):
     def _get_view_object_permissions(self, view):
         object_permissions = getattr(view, "required_object_permissions", None)
         if object_permissions is None:
-            return self._get_view_permissions(view)
+            result = self._get_view_permissions(view)
+        else:
+            result = object_permissions
+        return result
 
     def has_permission(self, request, view):
-        permissions = self._get_view_permissions(view)
-        user = request.user
-        for perm in permissions:
-            if not user.has_perm(perm):
+        """Check permissions for accessing the input view
+
+        This method will by default deny access unless permissions are
+        explicitly granted.
+
+        """
+
+        all_perms = self._get_view_permissions(view)
+        safe_perms = filter_out_unsafe_permissions(all_perms)
+        is_safe_method = request.method in permissions.SAFE_METHODS
+
+        perms_to_check = safe_perms if is_safe_method else all_perms
+        result = False
+        for perm in perms_to_check:
+            if request.user.has_perm(perm):
+                result = True
+            else:
                 result = False
                 break
-        else:
-            result = True
         return result
 
     def has_object_permission(self, request, view, obj):
-        permissions = self._get_view_object_permissions(view)
-        user = request.user
-        for perm in permissions:
-            if not user.has_perm(perm, obj):
+        all_permissions = self._get_view_object_permissions(view)
+        safe_permissions = filter_out_unsafe_permissions(all_permissions)
+        is_safe_method = request.method in permissions.SAFE_METHODS
+        for perm in (safe_permissions if is_safe_method else all_permissions):
+            if not request.user.has_perm(perm, obj):
                 result = False
                 break
         else:

--- a/smbportal/profiles/rules.py
+++ b/smbportal/profiles/rules.py
@@ -39,7 +39,10 @@ def has_profile(user):
 is_end_user = rules.is_group_member("end_users")
 is_privileged_user = rules.is_group_member("privileged_users")
 
-rules.add_perm("profiles.can_list_users", is_privileged_user)
-rules.add_perm("profiles.can_create", ~has_profile)
-rules.add_perm("profiles.can_view", has_profile)
-rules.add_perm("profiles.can_edit", has_profile & is_profile_owner)
+for perm, predicate in {
+    "can_list_users": is_privileged_user,
+    "can_create_profile": ~has_profile,
+    "can_view_profile": has_profile,
+    "can_edit_profile": has_profile & is_profile_owner,
+}.items():
+    rules.add_perm("profiles.{}".format(perm), predicate)

--- a/smbportal/profiles/views.py
+++ b/smbportal/profiles/views.py
@@ -19,6 +19,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.urls import reverse
+from django.utils.safestring import mark_safe
 from django.views.generic import CreateView
 from django.views.generic import DetailView
 from django.views.generic import UpdateView
@@ -169,9 +170,17 @@ class EndUserProfileCreateView(LoginRequiredMixin,
     model = models.EndUserProfile
     form_class = forms.EndUserProfileForm
     template_name_suffix = "_create"
-    success_message = "end-user profile created!"
     permission_required = "profiles.can_create"
     success_url = reverse_lazy("profile:update")
+
+    @property
+    def success_message(self):
+        create_bike_url = reverse("bikes:create")
+        return mark_safe(
+            "end-user profile created! "
+            "You can <a href='{}'>add a new bike now</a>".format(
+                create_bike_url)
+        )
 
     def get_login_url(self):
         if not self.request.user.is_authenticated:

--- a/smbportal/vehicles/forms.py
+++ b/smbportal/vehicles/forms.py
@@ -8,9 +8,13 @@
 #
 #########################################################################
 
+import logging
+
 from django import forms
 
 from . import models
+
+logger = logging.getLogger(__name__)
 
 
 class BikeForm(forms.ModelForm):
@@ -49,7 +53,8 @@ class BikeForm(forms.ModelForm):
 
         super().clean()
         nickname = self.cleaned_data.get("nickname")
-        if self.user.bikes.filter(nickname=nickname).exists():
+        if self.user.bikes.filter(nickname=nickname).exclude(
+                id=self.instance.id).exists():
             # FIXME: should be passing "nickname" as the ``field`` value here
             #        However, that makes the template render a non-styled
             #        message next to the failing field. By passing ``None``
@@ -78,4 +83,5 @@ class BikeForm(forms.ModelForm):
             "has_lights",
             "has_bags",
             "has_smb_sticker",
+            "other_details",
         )

--- a/smbportal/vehicles/forms.py
+++ b/smbportal/vehicles/forms.py
@@ -85,3 +85,29 @@ class BikeForm(forms.ModelForm):
             "has_smb_sticker",
             "other_details",
         )
+
+
+class BikePossessionHistoryForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop("user")
+        bike = kwargs.pop("bike", None)
+        super().__init__(*args, **kwargs)
+        self.instance.reporter = user
+        if bike is not None:
+            self.instance.bike = bike
+            del self.fields["bike"]
+        else:
+            self.fields["bike"].queryset = models.Bike.objects.filter(
+                owner=user)
+
+    class Meta:
+        model = models.BikePossessionHistory
+        fields = (
+            "bike",
+            "possession_state",
+            "details",
+        )
+        widgets = {
+            "possession_state": forms.RadioSelect,
+        }

--- a/smbportal/vehicles/models.py
+++ b/smbportal/vehicles/models.py
@@ -146,7 +146,7 @@ class Bike(Vehicle):
         unique_together = ("owner", "nickname")
 
     def __str__(self):
-        return "{0.id}({0.nickname})".format(self)
+        return "{0.nickname}".format(self)
 
     def get_absolute_url(self):
         return reverse("bikes:detail", kwargs={"pk": self.id})

--- a/smbportal/vehicles/rules.py
+++ b/smbportal/vehicles/rules.py
@@ -28,14 +28,21 @@ def is_bike_owner(user, bike):
     return bike.owner == user
 
 
-rules.add_perm("vehicles.can_list_bikes", profile_rules.is_privileged_user)
-rules.add_perm("vehicles.can_create_bike", profile_rules.is_end_user)
-rules.add_perm("vehicles.can_view_bike", is_bike_owner)
-rules.add_perm("vehicles.can_edit_bike", is_bike_owner)
-
-rules.add_perm(
-    "vehicles.can_list_physical_tags", profile_rules.is_privileged_user)
-rules.add_perm("vehicles.can_create_physical_tag", profile_rules.is_end_user)
-rules.add_perm("vehicles.can_view_physical_tag", is_bike_owner)
-rules.add_perm("vehicles.can_edit_physical_tag", is_bike_owner)
-
+for perm, predicate in {
+    "can_create_bike": profile_rules.is_end_user,
+    "can_create_bike_possession_history": profile_rules.is_privileged_user,
+    "can_create_own_bike_possession_history": profile_rules.is_end_user,
+    "can_create_physical_tag": profile_rules.is_end_user,
+    "can_delete_physical_tags": profile_rules.is_privileged_user,
+    "can_edit_bike": is_bike_owner,
+    "can_edit_physical_tag": is_bike_owner,
+    "can_list_bikes": profile_rules.is_privileged_user,
+    "can_list_own_bikes": profile_rules.is_end_user,
+    "can_list_bike_possession_history": profile_rules.is_privileged_user,
+    "can_list_own_bike_possession_history": profile_rules.is_end_user,
+    "can_list_physical_tags": profile_rules.is_privileged_user,
+    "can_list_own_physical_tags": profile_rules.is_end_user,
+    "can_view_physical_tag": is_bike_owner,
+    "can_view_bike": is_bike_owner,
+}.items():
+    rules.add_perm("vehicles.{}".format(perm), predicate)

--- a/smbportal/vehicles/templates/vehicles/bike_confirm_delete.html
+++ b/smbportal/vehicles/templates/vehicles/bike_confirm_delete.html
@@ -12,11 +12,12 @@
 
 {% block main %}
     <div class="col-lg-12">
-        <p>Are you sure you want to delete bike <b>{{ bike.pk }}({{ bike.nickname }})</b>?</p>
+        <p>Are you sure you want to delete bike <b>{{ bike.nickname }}</b>?</p>
         <form method="post">
             {% csrf_token %}
             {% buttons %}
-                <button type="submit" class="btn btn-danger btn-lg">Delete</button>
+                <a href="{% url 'bikes:detail' pk=bike.pk %}" class="btn btn-secondary btn-lg"><i class="fa fa-hand-o-left"></i> Go back</a>
+                <button type="submit" class="btn btn-danger btn-lg"><i class="fa fa-trash-o"></i> Delete bike</button>
             {% endbuttons %}
         </form>
     </div>

--- a/smbportal/vehicles/templates/vehicles/bike_detail.html
+++ b/smbportal/vehicles/templates/vehicles/bike_detail.html
@@ -12,14 +12,14 @@
         <div class="col-lg-8">
             <div class="row">
                 <div class="col-lg-4">
-                    <p>nickname: <em>{{ bike.nickname }}</em></p>
-                    <p>Type of bike: <em>{{ bike.bike_type }}</em></p>
-                    <p>Gears: <em>{{ bike.gear }}</em></p>
-                    <p>Brakes: <em>{{ bike.brake }}</em></p>
-                    <p>Brand: <em>{{ bike.brand }}</em></p>
-                    <p>Model: <em>{{ bike.model }}</em></p>
-                    <p>Color: <em>{{ bike.color }}</em></p>
-                    <p>Saddle: <em>{{ bike.saddle }}</em></p>
+                    <p>nickname: <strong>{{ bike.nickname }}</strong></p>
+                    <p>Type of bike: <strong>{{ bike.bike_type }}</strong></p>
+                    <p>Gears: <strong>{{ bike.gear }}</strong></p>
+                    <p>Brakes: <strong>{{ bike.brake }}</strong></p>
+                    <p>Brand: <strong>{{ bike.brand }}</strong></p>
+                    <p>Model: <strong>{{ bike.model }}</strong></p>
+                    <p>Color: <strong>{{ bike.color }}</strong></p>
+                    <p>Saddle: <strong>{{ bike.saddle }}</strong></p>
                 </div>
                 <div class="col-lg-4">
                     <p>Basket: <em><i class="fa {% if bike.has_basket %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
@@ -27,6 +27,7 @@
                     <p>Lights: <em><i class="fa {% if bike.has_lights %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
                     <p>Bags: <em><i class="fa {% if bike.has_bags %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
                     <p>SaveMyBike sticker: <em><i class="fa {% if bike.has_smb_sticker %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
+                    <p>Other details: <strong>{{ bike.other_details }}</strong></p>
                     <h4>Possession state</h4>
                     <p>{{ bike.get_current_possession_state.possession_state }}</p>
                     <h4>Tags</h4>

--- a/smbportal/vehicles/templates/vehicles/bike_detail.html
+++ b/smbportal/vehicles/templates/vehicles/bike_detail.html
@@ -10,51 +10,41 @@
 {% block content %}
     <div class="row">
         <div class="col-lg-8">
-            <div class="row">
-                <div class="col-lg-4">
-                    <p>nickname: <strong>{{ bike.nickname }}</strong></p>
-                    <p>Type of bike: <strong>{{ bike.bike_type }}</strong></p>
-                    <p>Gears: <strong>{{ bike.gear }}</strong></p>
-                    <p>Brakes: <strong>{{ bike.brake }}</strong></p>
-                    <p>Brand: <strong>{{ bike.brand }}</strong></p>
-                    <p>Model: <strong>{{ bike.model }}</strong></p>
-                    <p>Color: <strong>{{ bike.color }}</strong></p>
-                    <p>Saddle: <strong>{{ bike.saddle }}</strong></p>
-                </div>
-                <div class="col-lg-4">
-                    <p>Basket: <em><i class="fa {% if bike.has_basket %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
-                    <p>Cargo rack: <em><i class="fa {% if bike.has_cargo_rack %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
-                    <p>Lights: <em><i class="fa {% if bike.has_lights %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
-                    <p>Bags: <em><i class="fa {% if bike.has_bags %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
-                    <p>SaveMyBike sticker: <em><i class="fa {% if bike.has_smb_sticker %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
-                    <p>Other details: <strong>{{ bike.other_details }}</strong></p>
-                    <h4>Possession state</h4>
-                    <p>{{ bike.get_current_possession_state.possession_state }}</p>
-                    <h4>Tags</h4>
-                    <ul>
-                        {% for tag in bike.tags.all %}
-                            <li>{{ tag.epc }}</li>
-                        {% empty %}
-                            <li>This bike does not have any tags</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                <div class="col-lg-8 gallery-wrapper" data-pswp-uid="1">
-                    <div class="row">
-                        {% for photo in bike.picture_gallery.sample %}
-                            <div class="col-md-4 col-sm-6">
-                                <div class="gallery-item">
-                                    <a href="{{ photo.get_display_url }}" data-size="1280x853">
-                                        <img src="{{ photo.get_thumbnail_url }}" class="img-thumbnail" alt="{{ photo.title }}">
-                                    </a>
-                                </div>
+            <p>nickname: <strong>{{ bike.nickname }}</strong></p>
+            <p>Type of bike: <strong>{{ bike.bike_type }}</strong></p>
+            <p>Gears: <strong>{{ bike.gear }}</strong></p>
+            <p>Brakes: <strong>{{ bike.brake }}</strong></p>
+            <p>Brand: <strong>{{ bike.brand }}</strong></p>
+            <p>Model: <strong>{{ bike.model }}</strong></p>
+            <p>Color: <strong>{{ bike.color }}</strong></p>
+            <p>Saddle: <strong>{{ bike.saddle }}</strong></p>
+            <p>Basket: <em><i class="fa {% if bike.has_basket %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
+            <p>Cargo rack: <em><i class="fa {% if bike.has_cargo_rack %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
+            <p>Lights: <em><i class="fa {% if bike.has_lights %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
+            <p>Bags: <em><i class="fa {% if bike.has_bags %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
+            <p>SaveMyBike sticker: <em><i class="fa {% if bike.has_smb_sticker %}fa-check-square{% else %}fa-square-o{% endif %}"></i></em></p>
+            <p>Other details: <strong>{{ bike.other_details }}</strong></p>
+            <h4>Possession state</h4>
+            <p>{{ bike.get_current_possession_state.possession_state }}</p>
+            <h4>Tags</h4>
+            <ul>
+                {% for tag in bike.tags.all %}
+                    <li>{{ tag.epc }}</li>
+                {% empty %}
+                    <li>This bike does not have any tags</li>
+                {% endfor %}
+            </ul>
+            <div class="col-lg-8 gallery-wrapper" data-pswp-uid="1">
+                <div class="row">
+                    {% for photo in bike.picture_gallery.sample %}
+                        <div class="col-md-4 col-sm-6">
+                            <div class="gallery-item">
+                                <a href="{{ photo.get_display_url }}" data-size="1280x853">
+                                    <img src="{{ photo.get_thumbnail_url }}" class="img-thumbnail" alt="{{ photo.title }}">
+                                </a>
                             </div>
-                        {% endfor %}
-                    </div>
-                </div>
-                <div class="col-lg-4">
-                    <a class="btn btn-outline-primary" href="{% url 'bikes:update' pk=bike.pk %}">Edit bike</a>
-                    <a class="btn btn-outline-danger" href="{% url 'bikes:delete' pk=bike.pk %}">Delete bike</a>
+                        </div>
+                    {% endfor %}
                 </div>
             </div>
         </div>
@@ -70,6 +60,12 @@
                     <p><a href="" class="btn btn-secondary">print registry information</a></p>
                 </div>
             </div>
+        </div>
+        <div class="col">
+            <a class="btn btn-outline-primary" href="{% url 'bikes:update' pk=bike.pk %}"><i class="fa fa-pencil-square-o"></i> Edit bike details</a>
+            <a class="btn btn-outline-primary" href="{% url 'bikes:report-status' pk=bike.pk %}"><i class="fa fa-file-text-o"></i> Update bike status</a>
+            <a class="btn btn-outline-primary" href="{% url 'bikes:picture-upload' pk=bike.pk %}"><i class="fa fa-picture-o"></i> Add pictures</a>
+            <a class="btn btn-outline-danger" href="{% url 'bikes:delete' pk=bike.pk %}"><i class="fa fa-trash-o"></i> Delete bike</a>
         </div>
     </div>
     <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">

--- a/smbportal/vehicles/templates/vehicles/bike_picture_create.html
+++ b/smbportal/vehicles/templates/vehicles/bike_picture_create.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% breadcrumb bike.pk 'bikes:detail' pk=bike.pk %}
+    {% breadcrumb bike.nickname 'bikes:detail' pk=bike.pk %}
     {% breadcrumb 'add picture' 'bikes:picture-upload' pk=bike.pk %}
 {% endblock %}
 

--- a/smbportal/vehicles/templates/vehicles/bike_update.html
+++ b/smbportal/vehicles/templates/vehicles/bike_update.html
@@ -6,18 +6,17 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    {% breadcrumb bike.pk 'bikes:detail' pk=bike.pk %}
+    {% breadcrumb bike.nickname 'bikes:detail' pk=bike.pk %}
     {% breadcrumb 'edit' 'bikes:edit' pk=bike.pk %}
 {% endblock %}
 
 {% block main %}
     <div class="col-lg-12">
-        <a href="{% url 'bikes:picture-upload' pk=bike.pk %}" class="btn btn-secondary">Upload pictures</a>
         <form method="post" action="">
             {% csrf_token %}
             {% bootstrap_form form %}
             {% buttons %}
-                <button type="submit" class="btn btn-outline-primary btn-lg">Update bike</button>
+                <button type="submit" class="btn btn-primary btn-lg">Update bike</button>
             {% endbuttons %}
         </form>
     </div>

--- a/smbportal/vehicles/templates/vehicles/bikepossessionhistory_create.html
+++ b/smbportal/vehicles/templates/vehicles/bikepossessionhistory_create.html
@@ -1,0 +1,31 @@
+{% extends "vehicles/base.html" %}
+
+{% load i18n %}
+{% load bootstrap4 %}
+{% load django_bootstrap_breadcrumbs %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% if bike %}
+        {% breadcrumb bike.nickname 'bikes:detail' pk=bike.pk %}
+    {% endif %}
+    {% breadcrumb 'report status' 'bikes:report-status' pk=bike.pk %}
+{% endblock %}
+
+{% block page_title %}Report bike possession status{% endblock %}
+
+{% block main %}
+    <div class="col-lg-12">
+        {% if bike %}
+            <form method="post">
+                {% csrf_token %}
+                {% bootstrap_form form %}
+                {% buttons %}
+                    <button type="submit" class="btn btn-outline-primary btn-lg">Submit</button>
+                {% endbuttons %}
+            </form>
+        {% else %}
+            <p>You don't have any bikes yet.</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/smbportal/vehicles/urls.py
+++ b/smbportal/vehicles/urls.py
@@ -25,6 +25,11 @@ urlpatterns = [
         name="create"
     ),
     path(
+        route="report-status",
+        view=views.BikePossessionHistoryCreateView.as_view(),
+        name="report-status"
+    ),
+    path(
         route="<pk>",
         view=views.BikeDetailView.as_view(),
         name="detail"
@@ -38,6 +43,11 @@ urlpatterns = [
         route="<pk>/delete",
         view=views.BikeDeleteView.as_view(),
         name="delete"
+    ),
+    path(
+        route="<pk>/report-status",
+        view=views.BikePossessionHistoryCreateView.as_view(),
+        name="report-status"
     ),
     path(
         route="<pk>/pictures/upload",

--- a/smbportal/vehicles/views.py
+++ b/smbportal/vehicles/views.py
@@ -67,7 +67,7 @@ class BikeCreateView(LoginRequiredMixin, mixins.FormUpdatedMessageMixin,
         """Instantiate a form object
 
         We re-implement this method in order to pass the current user as an
-        initialization parameter. This is useful for perfoming validation on
+        initialization parameter. This is useful for performing validation on
         the form's fields.
 
         """
@@ -106,35 +106,32 @@ class BikeCreateView(LoginRequiredMixin, mixins.FormUpdatedMessageMixin,
 class BikeUpdateView(LoginRequiredMixin, mixins.FormUpdatedMessageMixin,
                      UpdateView):
     model = models.Bike
-    fields = (
-        "nickname",
-        "bike_type",
-        "gear",
-        "brake",
-        "brand",
-        "model",
-        "color",
-        "saddle",
-        "has_basket",
-        "has_cargo_rack",
-        "has_lights",
-        "has_bags",
-        "has_smb_sticker",
-        "other_details",
-    )
+    form_class = forms.BikeForm
     template_name_suffix = "_update"
 
     @property
     def success_message(self):
-        return "bike {!r} updated".format(self.object.nickname)
+        return "Bike {!r} updated".format(self.object.nickname)
 
     def get_success_url(self):
         bike = self.get_object()
         return reverse("bikes:detail", kwargs={"pk": bike.pk})
 
-    def form_valid(self, form):
-        form.instance.owner = self.request.user
-        return super().form_valid(form)
+    def get_form_kwargs(self):
+        """Instantiate a form object
+
+        We re-implement this method in order to pass the current user as an
+        initialization parameter. This is useful for performing validation on
+        the form's fields.
+
+        """
+
+        form_kwargs = super().get_form_kwargs()
+        form_kwargs.update({
+            "user": self.request.user,
+        })
+        logger.debug("BikeUpdateView form kwargs: {}".format(form_kwargs))
+        return form_kwargs
 
 
 class BikeDetailView(LoginRequiredMixin, DetailView):

--- a/smbportal/vehicles/views.py
+++ b/smbportal/vehicles/views.py
@@ -13,6 +13,7 @@ import logging
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.urls import reverse_lazy
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 class BikeListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     context_object_name = "bikes"
-    permission_required = "profiles.can_view"
+    permission_required = "vehicles.can_list_own_bikes"
 
     def get_queryset(self):
         return models.Bike.objects.filter(owner=self.request.user)
@@ -61,7 +62,7 @@ class BikeCreateView(LoginRequiredMixin, mixins.FormUpdatedMessageMixin,
         return "Created bike {!r}".format(self.object.nickname)
 
     def get_success_url(self):
-        return reverse("bikes:update", kwargs={"pk": self.object.pk})
+        return reverse("bikes:detail", kwargs={"pk": self.object.pk})
 
     def get_form_kwargs(self):
         """Instantiate a form object
@@ -108,10 +109,7 @@ class BikeUpdateView(LoginRequiredMixin, mixins.FormUpdatedMessageMixin,
     model = models.Bike
     form_class = forms.BikeForm
     template_name_suffix = "_update"
-
-    @property
-    def success_message(self):
-        return "Bike {!r} updated".format(self.object.nickname)
+    success_message = "Bike details updated!"
 
     def get_success_url(self):
         bike = self.get_object()
@@ -143,6 +141,12 @@ class BikeDeleteView(LoginRequiredMixin, DeleteView):
     model = models.Bike
     context_object_name = "bike"
     success_url = reverse_lazy("bikes:list")
+    success_message = "Bike deleted!"
+
+    def delete(self, request, *args, **kwargs):
+        result = super().delete(request, *args, **kwargs)
+        messages.success(request, self.success_message)
+        return result
 
 
 class BikePictureUploadView(CreateView):
@@ -162,15 +166,53 @@ class BikePictureUploadView(CreateView):
         return context_data
 
     def form_valid(self, form):
-        logger.debug("form stuff: {}".format(form.__dict__))
-        logger.debug("cleaned image: {}".format(form.cleaned_data["image"]))
         response = super().form_valid(form)
         photo = self.object
-        logger.debug("bike_pk: {}".format(self.kwargs.get("pk")))
         current_bike = models.Bike.objects.get(pk=self.kwargs.get("pk"))
-        logger.debug("current_bike: {}".format(current_bike))
         gallery = current_bike.picture_gallery
-        logger.debug("gallery: {}".format(gallery))
         gallery.photos.add(photo)
-        logger.debug("photo instance: {}".format(photo))
         return response
+
+
+class BikePossessionHistoryCreateView(LoginRequiredMixin,
+                                      mixins.FormUpdatedMessageMixin,
+                                      CreateView):
+    model = models.BikePossessionHistory
+    form_class = forms.BikePossessionHistoryForm
+    template_name_suffix = "_create"
+    success_message = "Bike status updated!"
+
+    def get_success_url(self):
+        pk = self.kwargs.get("pk")
+        if pk is not None:
+            result = reverse(
+                "bikes:detail",
+                kwargs={"pk": self.kwargs.get("pk")}
+            )
+        else:
+            result = reverse("bikes:list")
+        return result
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["bike"] = self.get_bike()
+        return context_data
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update({
+            "bike": self.get_bike(),
+            "user": self.request.user,
+            "initial": {
+                "possession_state": models.BikePossessionHistory.STOLEN,
+            }
+        })
+        return kwargs
+
+    def get_bike(self):
+        try:
+            bike = models.Bike.objects.get(pk=self.kwargs.get("pk"))
+        except models.Bike.DoesNotExist:
+            bike = None
+        return bike
+

--- a/tests/unittests/test_keycloakauth_permissions.py
+++ b/tests/unittests/test_keycloakauth_permissions.py
@@ -1,0 +1,42 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+"""Unit tests for the keycloakauth.permissions module"""
+
+from django.contrib.auth.models import Group
+
+import pytest
+
+import keycloakauth.permissions
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("perms, expected", [
+    (("list_stuff",), ["list_stuff",]),
+    (("create_stuff",), []),
+    (("create_stuff", "list_stuff"), ["list_stuff"]),
+    (("new_stuff",), []),
+    (("new_stuff", "list_stuff"), ["list_stuff"]),
+    (("edit_stuff",), []),
+    (("edit_stuff", "list_stuff"), ["list_stuff"]),
+    (("update_stuff",), []),
+    (("update_stuff", "list_stuff"), ["list_stuff"]),
+    (("change_stuff",), []),
+    (("change_stuff", "list_stuff"), ["list_stuff"]),
+    (("delete_stuff",), []),
+    (("delete_stuff", "list_stuff"), ["list_stuff"]),
+    (("remove_stuff",), []),
+    (("remove_stuff", "list_stuff"), ["list_stuff"]),
+])
+def test_filter_out_unsafe_permissions(perms, expected):
+    result = keycloakauth.permissions.filter_out_unsafe_permissions(perms)
+    assert result == expected
+


### PR DESCRIPTION
This PR has some assorted stuff, most notably:

- simplified `profiles` and `vehicles` apps' frontend-related stuff with some changes in views and templates
- added a page for reporting a bike as stolen (lost/found). For now it is accessible in two places:

  - as link in the portal's main navigation area (top of the screen)
  - as an action when viewing a bike's details page
 
- refactored `/api` stuff in order to make better use of permissions. The API should now allow a user with sufficient permissions to:

  - consult a list of all bikes registered on the platform  - `GET /bikes`
  - get additional bike details for each bike - `GET /bikes/{id}`
  - register new physical tags for a bike - `POST /tags`
  - delete a previously assigned tag for a bike - `DELETE /tags/{id}`
  - consult the possession status of each bike - `GET /bike-possession-history`
  - add new possession statuses for a bike (such as report it having been found) - `POST /bike-possession-history`

  A lower privileged user is only able to access information related to its own profile, bikes, bike status and tags.

  Note that filtering on the API is not implemented yet