### PR TITLE
fixed user serializer bug and added some tests

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -77,7 +77,6 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
     def get_id(self, obj):
         return obj.keycloak.UID
 
-
     def get_profile(self, obj):
         if obj.profile is not None:
             profile_class = type(obj.profile)
@@ -110,7 +109,6 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
             "first_name",
             "last_name",
             "nickname",
-            "sub",
             "profile",
             "profile_type",
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,11 @@
 
 """pytest configuration file"""
 
+from unittest import mock
+
+import pytest
+from rest_framework.test import APIRequestFactory
+
 
 def pytest_configure(config):
     config.addinivalue_line(
@@ -20,3 +25,16 @@ def pytest_configure(config):
         "markers",
         "integration: Run only integration tests",
     )
+
+
+@pytest.fixture(scope="session")
+def api_request_factory():
+    factory = APIRequestFactory()
+    return factory
+
+
+@pytest.fixture
+def mocked_user():
+    mocked_user_class = mock.MagicMock(
+        spec="api.serializers.profiles.models.SmbUser")
+    return mocked_user_class()

--- a/tests/unittests/test_api_serializers.py
+++ b/tests/unittests/test_api_serializers.py
@@ -1,0 +1,83 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+from unittest import mock
+
+from bossoidc.models import Keycloak
+from rest_framework.reverse import reverse
+import pytest
+
+from api import serializers
+
+pytestmark = pytest.mark.unit
+
+
+def test_smbuserhyperlinkedidentityfield_returns_uuid(api_request_factory,
+                                                      mocked_user):
+    fake_uuid = "fake_uuid"
+    fake_request = api_request_factory.get(
+        reverse("api:users-detail", kwargs={"pk": fake_uuid}))
+    user_detail_view_name = "api:users-detail"
+    field = serializers.SmbUserHyperlinkedIdentityField(
+        view_name=user_detail_view_name,
+        read_only=True
+    )
+    mocked_user.keycloak.return_value = mock.MagicMock(spec=Keycloak)
+    mocked_user.keycloak.UID = fake_uuid
+    result = field.get_url(
+        mocked_user,
+        view_name=user_detail_view_name,
+        request=fake_request,
+        format=None
+    )
+    assert result.endswith("{}/".format(fake_uuid))
+
+
+def test_smbuserhyperlinkedrelatedfield_returns_uuid(api_request_factory,
+                                                     mocked_user):
+    fake_uuid = "fake_uuid"
+    fake_request = api_request_factory.get(
+        reverse("api:bikes-detail", kwargs={"pk": "phony"}))
+    user_detail_view_name = "api:users-detail"
+    field = serializers.SmbUserHyperlinkedRelatedField(
+        view_name=user_detail_view_name,
+        read_only=True
+    )
+    mocked_user.keycloak.return_value = mock.MagicMock(spec=Keycloak)
+    mocked_user.keycloak.UID = fake_uuid
+    result = field.get_url(
+        mocked_user,
+        view_name=user_detail_view_name,
+        request=fake_request,
+        format=None
+    )
+    assert result.endswith("{}/".format(fake_uuid))
+
+
+def test_smbuserserializer_returns_uuid(api_request_factory, mocked_user):
+    """verify that SmbUserSerializer returns the correct id data
+
+    SmbUserSerializer should show ``id`` as being the keycloak UUID. Django
+    identifier must be kept private
+
+    """
+
+    fake_uuid = "fake uuid"
+    fake_request = api_request_factory.get(
+        reverse("api:users-detail", kwargs={"pk": fake_uuid}))
+    mocked_user.keycloak.return_value = mock.MagicMock(spec=Keycloak)
+    mocked_user.keycloak.UID = fake_uuid
+    mocked_user.profile = None
+    serializer = serializers.SmbUserSerializer(
+        instance=mocked_user,
+        context={"request": fake_request}
+    )
+    serializer_data = serializer.data
+    assert serializer_data["id"] == fake_uuid


### PR DESCRIPTION
This PR fixes a bug introduced in the last PR when the `sub` field got deleted from the base user model.

It also adds some unit tests and test-related stuff