### PR TITLE
added a view to print bike registration info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 media
+static_root
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -194,6 +194,10 @@ LOCALE_PATHS = (
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
+STATIC_ROOT = get_environment_variable(
+    "DJANGO_STATIC_ROOT",
+    default_value=str(pathlib.Path(BASE_DIR).parent / "static_root"),
+)
 STATIC_URL = "/static/"
 
 STATICFILES_DIRS = [

--- a/smbportal/locale/it/LC_MESSAGES/django.po
+++ b/smbportal/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-28 09:15+0000\n"
+"POT-Creation-Date: 2018-06-28 15:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,6 +28,42 @@ msgstr "Italian"
 #: profiles/models.py:90
 msgid "Short user biography"
 msgstr "Breve biografia"
+
+#: profiles/models.py:132
+msgid "Habitual (more than 10 travels per month)"
+msgstr ""
+
+#: profiles/models.py:136
+msgid "Occasional (once per month)"
+msgstr ""
+
+#: profiles/models.py:140
+msgid "Rare (less than 10 travels per year)"
+msgstr ""
+
+#: profiles/models.py:144
+msgid "Never"
+msgstr ""
+
+#: profiles/models.py:163
+msgid "Habitual (at least once a week on average)"
+msgstr ""
+
+#: profiles/models.py:167
+msgid "Habitual (at least once a month)"
+msgstr ""
+
+#: profiles/models.py:171
+msgid "Seasonal (mainly used in the Summer)"
+msgstr ""
+
+#: profiles/models.py:175
+msgid "Rare (less than once a month)"
+msgstr ""
+
+#: profiles/models.py:179
+msgid "Never use a bicycle to move around in the city"
+msgstr ""
 
 #: profiles/views.py:118
 #, fuzzy
@@ -328,23 +364,20 @@ msgstr "Completa il profilo per utente con ruolo speciale"
 msgid "Note"
 msgstr ""
 
-#: templates/profiles/privilegeduserprofile_create.html:40
+#: templates/profiles/privilegeduserprofile_create.html:39
 msgid ""
-"\n"
-"                                    Registering as a privileged user "
-"requires manual authorization from one of the platform's administrators.\n"
-"                                    Your application will be moderated and "
-"you will be notified via e-mail. Until then you will not\n"
-"                                    be able to use the portal\n"
-"                                "
+"Registering as a privileged user requires manual authorization from one of "
+"the platform's administrators. Your application will be moderated and you "
+"will be notified via e-mail. Until then you will not be able to use the "
+"portal"
 msgstr ""
 
-#: templates/profiles/privilegeduserprofile_create.html:51
+#: templates/profiles/privilegeduserprofile_create.html:45
 #: templates/vehicles/bike_picture_confirm_delete.html:23
 msgid "Go back"
 msgstr "Torna indietro"
 
-#: templates/profiles/privilegeduserprofile_create.html:52
+#: templates/profiles/privilegeduserprofile_create.html:46
 msgid "Register as privileged user"
 msgstr "Registrati per un altro ruolo utente"
 
@@ -447,6 +480,7 @@ msgid "With owner"
 msgstr "In possesso del propretario"
 
 #: templates/vehicles/bike_detail.html:41
+#: templates/vehicles/tagregistration.html:28
 msgid "Registration code"
 msgstr "Registrazione"
 
@@ -625,6 +659,36 @@ msgstr "Segnala come smarrita"
 msgid "Report lost bike"
 msgstr "Segnala una bici smarrita"
 
+#: templates/vehicles/tagregistration.html:18
+#, fuzzy, python-format
+#| msgid "Registration code"
+msgid "Registration code for bike %(nickname)s"
+msgstr "Registrazione"
+
+#: templates/vehicles/tagregistration.html:22
+#, python-format
+msgid "User: %(email)s"
+msgstr ""
+
+#: templates/vehicles/tagregistration.html:23
+#, python-format
+msgid "User ID: %(uid)s"
+msgstr ""
+
+#: templates/vehicles/tagregistration.html:24
+msgid ""
+"Use your bike's registration code to obtain RFID tags. Apply these tags to "
+"your bike and enable additional functionality on the portal, such as "
+"tracking your bike\n"
+"                "
+msgstr ""
+
+#: templates/vehicles/tagregistration.html:30
+#, fuzzy
+#| msgid "Print bike registry info"
+msgid "Print registration information"
+msgstr "Stampa le informazioni di registrazione della bicibletta"
+
 #: vehiclemonitor/models.py:31
 msgid "Either this field or `address` must be given"
 msgstr ""
@@ -651,6 +715,50 @@ msgstr "E' stata già inserita una foto con lo stesso nome"
 msgid "Must select at least one picture to delete"
 msgstr "Selezionare almeno un'immagine da eliminare"
 
+#: vehicles/models.py:106
+msgid "racing"
+msgstr ""
+
+#: vehicles/models.py:107
+msgid "city"
+msgstr ""
+
+#: vehicles/models.py:108
+msgid "mountain"
+msgstr ""
+
+#: vehicles/models.py:109
+msgid "foldable"
+msgstr ""
+
+#: vehicles/models.py:116
+msgid "single ring"
+msgstr ""
+
+#: vehicles/models.py:117
+msgid "groupset below 18 speeds"
+msgstr ""
+
+#: vehicles/models.py:118
+msgid "groupset above 18 speeds"
+msgstr ""
+
+#: vehicles/models.py:119
+msgid "electric"
+msgstr ""
+
+#: vehicles/models.py:126
+msgid "disk"
+msgstr ""
+
+#: vehicles/models.py:127
+msgid "cantilevel"
+msgstr ""
+
+#: vehicles/models.py:128
+msgid "coaster"
+msgstr ""
+
 #: vehicles/models.py:187
 msgid "Bike last seen position"
 msgstr "Ultima positione rilevata della bicicletta"
@@ -659,41 +767,41 @@ msgstr "Ultima positione rilevata della bicicletta"
 msgid "Electronic Product Code"
 msgstr "Codice prodotto"
 
-#: vehicles/views.py:68
+#: vehicles/views.py:69
 #, fuzzy
 #| msgid "Create bike"
 msgid "Created bike {}"
 msgstr "Aggiungi una nuova bicicletta"
 
-#: vehicles/views.py:121
+#: vehicles/views.py:122
 #, fuzzy
 #| msgid "Bike details"
 msgid "Bike details updated!"
 msgstr "Dettagli della bici"
 
-#: vehicles/views.py:140
+#: vehicles/views.py:141
 #, fuzzy
 #| msgid "Edit bike details"
 msgid "Update bike details"
 msgstr "Modifica i dati della bicicletta"
 
-#: vehicles/views.py:157
+#: vehicles/views.py:158
 #, fuzzy
 #| msgid "Bike details"
 msgid "Bike deleted!"
 msgstr "Dettagli della bici"
 
-#: vehicles/views.py:187
+#: vehicles/views.py:188
 #, fuzzy
 #| msgid "Bike Pictures"
 msgid "Bike picture uploaded!"
 msgstr "Foto della bicicletta"
 
-#: vehicles/views.py:232
+#: vehicles/views.py:233
 msgid "Pictures have been deleted!"
 msgstr "Immagini eliminate!"
 
-#: vehicles/views.py:260
+#: vehicles/views.py:261
 msgid "Bike status updated!"
 msgstr "Lo stato è stato aggiornato!"
 

--- a/smbportal/profiles/models.py
+++ b/smbportal/profiles/models.py
@@ -129,19 +129,19 @@ class MobilityHabitsSurvey(models.Model):
         choices=(
             (
                 FREQUENT_PUBLIC_TRANSPORT_USER,
-                "Habitual (more than 10 travels per month)"
+                _("Habitual (more than 10 travels per month)")
             ),
             (
                 OCCASIONAL_PUBLIC_TRANSPORT_USER,
-                "Occasional (once per month)"
+                _("Occasional (once per month)")
             ),
             (
                 RARE_PUBLIC_TRANSPORT_USER,
-                "Rare (less than 10 travels per year)"
+                _("Rare (less than 10 travels per year)")
             ),
             (
                 NOT_A_PUBLIC_TRANSPORT_USER,
-                "Never"
+                _("Never")
             ),
         ),
         default=RARE_PUBLIC_TRANSPORT_USER,
@@ -160,23 +160,23 @@ class MobilityHabitsSurvey(models.Model):
         choices=(
             (
                 FREQUENT_BICYCLE_USER,
-                "Habitual (at least once a week on average)"
+                _("Habitual (at least once a week on average)")
             ),
             (
                 OCCASIONAL_BICYCLE_USER,
-                "Habitual (at least once a month)"
+                _("Habitual (at least once a month)")
             ),
             (
                 SEASONAL_BICYCLE_USER,
-                "Seasonal (mainly used in the Summer)"
+                _("Seasonal (mainly used in the Summer)")
             ),
             (
                 RARE_BICYCLE_USER,
-                "Rare (less than once a month)"
+                _("Rare (less than once a month)")
             ),
             (
                 NOT_A_BICYCLE_USER,
-                "Never use a bicycle to move around in the city"
+                _("Never use a bicycle to move around in the city")
             ),
         ),
         default=RARE_BICYCLE_USER,

--- a/smbportal/templates/profiles/privilegeduserprofile_create.html
+++ b/smbportal/templates/profiles/privilegeduserprofile_create.html
@@ -36,13 +36,7 @@
                     <div class="card text-white bg-info text-center mb-3">
                         <div class="card-body">
                             <h4 class="card-title">{% trans "Note" %}</h4>
-                            <p class="card-text">
-                                {% blocktrans %}
-                                    Registering as a privileged user requires manual authorization from one of the platform's administrators.
-                                    Your application will be moderated and you will be notified via e-mail. Until then you will not
-                                    be able to use the portal
-                                {% endblocktrans %}
-                            </p>
+                            <p class="card-text">{% blocktrans %}Registering as a privileged user requires manual authorization from one of the platform's administrators. Your application will be moderated and you will be notified via e-mail. Until then you will not be able to use the portal{% endblocktrans %}</p>
                         </div>
                     </div>
                     <form method="post">

--- a/smbportal/templates/vehicles/bike_detail.html
+++ b/smbportal/templates/vehicles/bike_detail.html
@@ -136,7 +136,7 @@
     </div>
     <div class="col-lg-3 col-md-4 order-md-2 r5_m_t_20">
         <nav class="list-group">
-            <a href="" class="list-group-item list-group-item-action"><i class="fa fa-bicycle"></i> {% trans "Print bike registry info" %}</a>
+            <a href="{% url 'bikes:tag-registration' pk=bike.pk %}" class="list-group-item list-group-item-action"><i class="fa fa-bicycle"></i> {% trans "Print bike registry info" %}</a>
             <a href="{% url 'monitor:list' bike_pk=bike.pk %}" class="list-group-item list-group-item-action"><i class="fa fa-map-o"></i> {% trans "View bike observations" %}</a>
             <a
                     id="updateBike"

--- a/smbportal/templates/vehicles/tagregistration.html
+++ b/smbportal/templates/vehicles/tagregistration.html
@@ -1,0 +1,40 @@
+{% load static %}
+{% load i18n %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html" charset="utf-8">
+    <link rel="stylesheet" media="all" href="{% static 'base/css/vendor.min.css' %}">
+    <link id="mainStyles" rel="stylesheet" media="all" href="{% static 'base/css/styles.css'%}">
+    <title>Save my bike</title>
+</head>
+<body>
+    <div class="container">
+        <div class="card margin-top-1x border-primary">
+            <div class="card-header text-center bg-white">
+                <img src="{% static 'base/img/logo.png' %}" alt="save-my-bike logo">
+            </div>
+            <div class="card-body bg_svg_green text-center text-white">
+                <h3 class="card-title">{% blocktrans with nickname=bike.nickname %}Registration code for bike {{ nickname }}{% endblocktrans %}</h3>
+                <div>
+                    <i class="fa fa-bicycle f-s-200"></i>
+                </div>
+                <h4 class="text-white">{% blocktrans with email=user.email %}User: {{ email }}{%endblocktrans%}</h4>
+                <p class="card-text text-sm">{% blocktrans with uid=user.keycloak.UID %}User ID: {{ uid }}{%endblocktrans%}</p>
+                <p class="card-text text-lg">{% blocktrans %}Use your bike's registration code to obtain RFID tags. Apply these tags to your bike and enable additional functionality on the portal, such as tracking your bike
+                {% endblocktrans %}</p>
+            </div>
+            <div class="card-footer bg-white text-center">
+                <span class="text-muted text-sm">{% trans 'Registration code' %}</span>
+                <h1>{{ bike.pk }}</h1>
+                <button id="printButton" type="button" class="btn btn-outline-primary">{% trans 'Print registration information' %}</button>
+            </div>
+        </div>
+    </div>
+<script type="text/javascript">
+    document.getElementById('printButton').addEventListener('click', function () {
+      window.print()
+    })
+</script>
+</body>
+</html>

--- a/smbportal/vehicles/models.py
+++ b/smbportal/vehicles/models.py
@@ -103,29 +103,29 @@ class Bike(Vehicle):
     bike_type = models.CharField(
         max_length=20,
         choices=(
-            (RACING_BIKE, RACING_BIKE),
-            (CITY_BIKE, CITY_BIKE),
-            (MOUNTAIN_BIKE, MOUNTAIN_BIKE),
-            (FOLDABLE_BIKE, FOLDABLE_BIKE),
+            (RACING_BIKE, _("racing")),
+            (CITY_BIKE, _("city")),
+            (MOUNTAIN_BIKE, _("mountain")),
+            (FOLDABLE_BIKE, _("foldable")),
         ),
         default=CITY_BIKE,
     )
     gear = models.CharField(
         max_length=50,
         choices=(
-            (SINGLE_RING_GEAR, SINGLE_RING_GEAR),
-            (GROUPSET_UNDER_18_SPEED_GEAR, GROUPSET_UNDER_18_SPEED_GEAR),
-            (GROUPSET_ABOVE_18_SPEED_GEAR, GROUPSET_ABOVE_18_SPEED_GEAR),
-            (ELECTRIC_GEAR, ELECTRIC_GEAR),
+            (SINGLE_RING_GEAR, _("single ring")),
+            (GROUPSET_UNDER_18_SPEED_GEAR, _("groupset below 18 speeds")),
+            (GROUPSET_ABOVE_18_SPEED_GEAR, _("groupset above 18 speeds")),
+            (ELECTRIC_GEAR, _("electric")),
         ),
         default=GROUPSET_ABOVE_18_SPEED_GEAR,
     )
     brake = models.CharField(
         max_length=30,
         choices=(
-            (DISK_BRAKE, DISK_BRAKE),
-            (CANTILEVER_BRAKE, CANTILEVER_BRAKE),
-            (COASTER_BRAKE, COASTER_BRAKE),
+            (DISK_BRAKE, _("disk")),
+            (CANTILEVER_BRAKE, _("cantilevel")),
+            (COASTER_BRAKE, _("coaster")),
         ),
         default=DISK_BRAKE,
     )

--- a/smbportal/vehicles/urls.py
+++ b/smbportal/vehicles/urls.py
@@ -35,6 +35,11 @@ urlpatterns = [
         name="detail"
     ),
     path(
+        route="<pk>/tag-registration",
+        view=views.TagRegistrationTemplateView.as_view(),
+        name="tag-registration"
+    ),
+    path(
         route="<pk>/update",
         view=views.BikeUpdateView.as_view(),
         name="update"

--- a/smbportal/vehicles/views.py
+++ b/smbportal/vehicles/views.py
@@ -26,6 +26,7 @@ from django.views.generic import CreateView
 from django.views.generic import DeleteView
 from django.views.generic import DetailView
 from django.views.generic import ListView
+from django.views.generic import TemplateView
 from django.views.generic import UpdateView
 from photologue.models import Gallery
 from photologue.models import Photo
@@ -282,3 +283,13 @@ class BikeStatusCreateView(LoginRequiredMixin,
             "user": self.request.user,
         })
         return kwargs
+
+
+class TagRegistrationTemplateView(LoginRequiredMixin, TemplateView):
+    template_name = "vehicles/tagregistration.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        current_bike = get_current_bike(self.kwargs)
+        context["bike"] = current_bike
+        return context


### PR DESCRIPTION
This PR adds a view for printing a bike's registration info. This is useful for the user, when wanting to get RFID tags for a bike.

Also included is a fix for some missing translation strings in models.