### PR TITLE
changed settings for mapping admin groups with keycloak

### DIFF
--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -266,8 +266,8 @@ KEYCLOAK = {
     "base_url": get_environment_variable(
         "KEYCLOAK_BASE_URL", "http://localhost:8080"),
     "realm": get_environment_variable("KEYCLOAK_REALM"),
-    "admin_role": "realm_admin",
-    "staff_role": "staff_member",
+    "admin_role": "portal_admin",
+    "staff_role": "portal_staff",
     "client_id": get_environment_variable("DJANGO_KEYCLOAK_CLIENT_ID"),
     "client_public_uri": get_environment_variable(
         "DJANGO_PUBLIC_URL", "http://localhost:8000"),


### PR DESCRIPTION
This PR does a small change to the default names of the mappings between django `superuser` and `staff` roles and keycloak.

- keycloak users that have the `portal_admin` role are now mapped to django superusers (i.e. django admins).
- keycloak users that have the `portal_staff` role are now mapped to django staff users (i.e. they can access the admin area)