### PR TITLE
added bike pictures to the details endpoint

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -181,6 +181,15 @@ class BikeDetailSerializer(BikeListSerializer):
         view_name="api:picture-galleries-detail",
         read_only=True
     )
+    pictures = serializers.SerializerMethodField()
+
+    def get_pictures(self, bike):
+        serializer = PictureSerializer(
+            instance=bike.picture_gallery.photos.all(),
+            context=self.context,
+            many=True
+        )
+        return [item["image"] for item in serializer.data]
 
     class Meta:
         model = vehicles.models.Bike
@@ -189,6 +198,7 @@ class BikeDetailSerializer(BikeListSerializer):
             "id",
             "owner",
             "picture_gallery",
+            "pictures",
             "tags",
             "last_update",
             "bike_type",


### PR DESCRIPTION
This PR adds a `pictures` property to the representation returned by the `/bikes/{id}` API endpoint. This is a list with URLs for each of the bike's pictures Example response: 

```json
{
  "url": "http://10.0.1.164:8000/api/bikes/a9c952f8-b4b8-45e9-ab1a-5d2b53a89dd7/",
  "id": "a9c952f8-b4b8-45e9-ab1a-5d2b53a89dd7",
  "owner": "http://10.0.1.164:8000/api/users/db92e41c-c7bc-4423-a242-a71fca14d351/",
  "picture_gallery": "http://10.0.1.164:8000/api/picture-galleries/32/",
  "pictures": [
    "http://10.0.1.164:8000/media/photologue/photos/bike2_o6dU0XL.jpeg",
    "http://10.0.1.164:8000/media/photologue/photos/61xd6-xh8ZL._SX466__p4FCFYt.jpg",
    "http://10.0.1.164:8000/media/photologue/photos/Screenshot_from_2016-07-03_01-35-17.png",
    "http://10.0.1.164:8000/media/photologue/photos/09bbcf8f5bf318031c46922e89b40fc4.jpg",
    "http://10.0.1.164:8000/media/photologue/photos/0e83db8b2a0a66a67f7f0016882a0ead.jpg",
    "http://10.0.1.164:8000/media/photologue/photos/image20160501_143051419.jpg",
    "http://10.0.1.164:8000/media/photologue/photos/image20160501_143112702.jpg",
    "http://10.0.1.164:8000/media/photologue/photos/Screenshot_from_2016-07-05_23-10-08.png"
  ],
  "tags": [],
  "last_update": "2018-06-29T23:51:29.113079Z",
  "bike_type": "racing",
  "gear": "groupset above 18 speeds",
  "brake": "disk",
  "nickname": "mina",
  "brand": "Dahon",
  "model": "Cur",
  "color": "White",
  "saddle": "",
  "has_basket": false,
  "has_cargo_rack": false,
  "has_bags": false,
  "has_smb_sticker": false,
  "other_details": "This is my fave bike in the whole wide world!\r\n\r\nIt is soo beaufiul I jus' wanna cry",
  "current_status": {
    "url": "http://10.0.1.164:8000/api/bike-statuses/90/",
    "lost": true
  }
}
```