### PR TITLE
fixed incorrect definition of BASE_DIR

### DIFF
--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -46,7 +46,7 @@ def get_list_env_value(environment_value, separator=":", default_value=None):
     return [item for item in raw_value.split(separator) if item != ""]
 
 
-BASE_DIR = str(pathlib.Path(__file__).parents[2])
+BASE_DIR = str(pathlib.Path(os.path.abspath(__file__)).parents[2])
 
 
 # Quick-start development settings - unsuitable for production
@@ -56,7 +56,7 @@ BASE_DIR = str(pathlib.Path(__file__).parents[2])
 SECRET_KEY = get_environment_variable("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = get_boolean_env_value("DJANGO_DEBUG", False)
+DEBUG = get_boolean_env_value("DJANGO_DEBUG", "false")
 
 ALLOWED_HOSTS = get_list_env_value(
     "DJANGO_ALLOWED_HOSTS", separator=" ", default_value="*")


### PR DESCRIPTION
This PR fixes an incorrect definition of the `BASE_DIR` setting.

The previous definition triggered a subtle difference in the attribution of the django base dir. This difference caused a bug in which the user-uploaded bike pictures were not being found, due to an incorrect interpretation of the `MEDIA_ROOT` setting.

The root of the bug is the different meaning of the `__file__` variable when the app is loaded with a relative path. More details at:

https://stackoverflow.com/a/22866630/8442046

This bug only manifested now, with the move to use `uwsgi` instead of the django server in the staging environment.