### PR TITLE
add email notifications for user and bike registration/deletion

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 --requirement production.txt
 
+django-sslserver==0.20
 flake8==3.5.0
 pytest==3.6.0
 pytest-django==3.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,10 @@
 # pytest configuration file
 
 [tool:pytest]
-addopts = --verbose --reuse-db --flake8
+addopts = --verbose --reuse-db --flake8 --ds=base.settings.test
 python_paths = smbportal
 flake8-ignore =
     manage.py F401
-    base/settings/dev.py F401 F403
+    base/settings/dev.py F401 F403 F405
+    base/settings/test.py F401 F403
     */migrations/*.py ALL

--- a/smbportal/base/management/commands/setupgeoip.py
+++ b/smbportal/base/management/commands/setupgeoip.py
@@ -77,4 +77,3 @@ class Command(BaseCommand):
                     tar.extract(member, str(target_path.parent))
         self.stdout.write("Removing {}...".format(download_target))
         download_target.unlink()
-

--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -191,6 +191,8 @@ IPWARE = {
     "proxy_count": 1,
 }
 
+SECURE_SSL_REDIRECT = True
+
 LANGUAGES = (
     ("en", _("English")),
     ("it", _("Italian")),

--- a/smbportal/base/settings/dev.py
+++ b/smbportal/base/settings/dev.py
@@ -12,6 +12,10 @@
 
 from .base import *
 
+INSTALLED_APPS.extend([
+    "sslserver",
+])
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/smbportal/base/settings/test.py
+++ b/smbportal/base/settings/test.py
@@ -8,18 +8,8 @@
 #
 #########################################################################
 
-import uuid
+"""This file is here to set some testing-specific values"""
 
-from django.apps import AppConfig
-from django.db.models.signals import post_save
+from .base import *
 
-
-class ProfilesConfig(AppConfig):
-    name = "profiles"
-
-    def ready(self):
-        from . import signals
-        post_save.connect(
-            signals.notify_profile_created,
-            dispatch_uid=str(uuid.uuid4())
-        )
+SECURE_SSL_REDIRECT = False

--- a/smbportal/locale/it/LC_MESSAGES/django.po
+++ b/smbportal/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-11 22:10+0000\n"
+"POT-Creation-Date: 2018-07-13 15:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: base/settings/base.py:185
+#: base/settings/base.py:197
 msgid "English"
 msgstr "English"
 
-#: base/settings/base.py:186
+#: base/settings/base.py:198
 msgid "Italian"
 msgstr "Italian"
 
@@ -559,6 +559,24 @@ msgstr ""
 msgid "Privileged user registration request"
 msgstr "Richiesta di registrazione da un utente privilegiato"
 
+#: templates/profiles/mail/profile_created_message.txt:1
+#, python-format
+msgid ""
+"Welcome to the savemybike portal!\n"
+"\n"
+"You registered a profile of type %(profile_type)s. Your username is "
+"%(username)s.\n"
+"\n"
+"Access your profile details page at:\n"
+"\n"
+"%(profile_url)s\n"
+"\n"
+msgstr ""
+
+#: templates/profiles/mail/profile_created_subject.txt:1
+msgid "User created"
+msgstr ""
+
 #: templates/profiles/mobilityhabitssurvey_create.html:9
 msgid "new survey"
 msgstr "Nuovo sondaggio"
@@ -903,7 +921,7 @@ msgstr ""
 msgid "There are no pictures for this bike yet"
 msgstr "Non sono predenti fotografie di questa bicicletta"
 
-#: templates/vehicles/bikegallery_detail.html:36 vehicles/forms.py:258
+#: templates/vehicles/bikegallery_detail.html:36 vehicles/forms.py:276
 msgid "Upload picture"
 msgstr "Carica foto"
 
@@ -934,6 +952,37 @@ msgstr "Segnala come smarrita"
 #: templates/vehicles/bikestatus_create.html:30 vehicles/forms.py:177
 msgid "Report lost bike"
 msgstr "Segnala una bici smarrita"
+
+#: templates/vehicles/mail/bike_created_message.txt:1
+#, python-format
+msgid ""
+"Bike %(nickname)s has been successfully registered on the portal.\n"
+"\n"
+"You can access the bike details page at:\n"
+"\n"
+"%(bike_url)s\n"
+"\n"
+msgstr ""
+
+#: templates/vehicles/mail/bike_created_subject.txt:1
+#, python-format
+msgid "Bike %(nickname)s has been registered"
+msgstr ""
+
+#: templates/vehicles/mail/bike_deleted_message.txt:1
+#, python-format
+msgid ""
+"Bike %(nickname)s has been successfully deleted from the portal.\n"
+"\n"
+"You can add more bikes by visiting:\n"
+"\n"
+"%(bike_list_url)s\n"
+"\n"
+msgstr ""
+
+#: templates/vehicles/mail/bike_deleted_subject.txt:1
+msgid "Bike %(nickname)s has been deleted"
+msgstr ""
 
 #: templates/vehicles/tagregistration.html:18
 #, python-format
@@ -1015,19 +1064,19 @@ msgstr "Dettagli"
 msgid "A bike with that nickname already exists"
 msgstr "E' già presente una bicicletta con questo nome"
 
-#: vehicles/forms.py:236
+#: vehicles/forms.py:254
 msgid "image"
 msgstr "Immagine"
 
-#: vehicles/forms.py:272
+#: vehicles/forms.py:290
 msgid "could not read uploaded image"
 msgstr "Non è stato possibile leggere l'immagine caricata"
 
-#: vehicles/forms.py:300
+#: vehicles/forms.py:318
 msgid "Already uploaded a picture with that name"
 msgstr "E' stata già inserita una foto con lo stesso nome"
 
-#: vehicles/forms.py:335
+#: vehicles/forms.py:353
 msgid "Must select at least one picture to delete"
 msgstr "Selezionare almeno un'immagine da eliminare"
 

--- a/smbportal/profiles/models.py
+++ b/smbportal/profiles/models.py
@@ -43,12 +43,12 @@ class SmbUser(AbstractUser):
 
     @property
     def profile(self):
-        attibute_names = (
+        attribute_names = (
             "enduserprofile",
             "privilegeduserprofile",
             # add more profiles for analysts, prize managers, etc
         )
-        for attr in attibute_names:
+        for attr in attribute_names:
             try:
                 profile = getattr(self, attr)
                 break

--- a/smbportal/profiles/signals.py
+++ b/smbportal/profiles/signals.py
@@ -1,0 +1,49 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+import logging
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+
+from . import models
+
+logger = logging.getLogger(__name__)
+
+
+def notify_profile_created(sender, **kwargs):
+    sender_classes = (
+        models.EndUserProfile,
+        models.PrivilegedUserProfile,
+    )
+    if sender in sender_classes and kwargs.get("created"):
+        logger.debug("profile created")
+        profile = kwargs.get("instance")
+        user = profile.user
+        current_site = Site.objects.get_current()
+        profile_type = profile.__class__.__name__.lower().replace(
+            "profile", "")
+        context = {
+            "site_name": current_site.name,
+            "profile_type": profile_type,
+            "username": user.username,
+            "profile_url": "https://{}{}".format(
+                current_site.domain, user.get_absolute_url())
+        }
+        send_mail(
+            subject=render_to_string(
+                "profiles/mail/profile_created_subject.txt", context=context),
+            message=render_to_string(
+                "profiles/mail/profile_created_message.txt", context=context),
+            from_email=settings.MAIL_SENDER_ADDRESS,
+            recipient_list=[user.email]
+        )

--- a/smbportal/templates/profiles/mail/profile_created_message.txt
+++ b/smbportal/templates/profiles/mail/profile_created_message.txt
@@ -1,0 +1,9 @@
+{% load i18n %}{% blocktrans %}Welcome to the savemybike portal!
+
+You registered a profile of type {{ profile_type }}. Your username is {{ username }}.
+
+Access your profile details page at:
+
+{{ profile_url }}
+
+{% endblocktrans %}

--- a/smbportal/templates/profiles/mail/profile_created_subject.txt
+++ b/smbportal/templates/profiles/mail/profile_created_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{{ site_name }} - {% trans 'User created' %}

--- a/smbportal/templates/vehicles/mail/bike_created_message.txt
+++ b/smbportal/templates/vehicles/mail/bike_created_message.txt
@@ -1,0 +1,7 @@
+{% load i18n %}{% blocktrans %}Bike {{ nickname }} has been successfully registered on the portal.
+
+You can access the bike details page at:
+
+{{ bike_url }}
+
+{% endblocktrans %}

--- a/smbportal/templates/vehicles/mail/bike_created_subject.txt
+++ b/smbportal/templates/vehicles/mail/bike_created_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{{ site_name }} - {% blocktrans%}Bike {{ nickname }} has been registered{% endblocktrans %}

--- a/smbportal/templates/vehicles/mail/bike_deleted_message.txt
+++ b/smbportal/templates/vehicles/mail/bike_deleted_message.txt
@@ -1,0 +1,7 @@
+{% load i18n %}{% blocktrans %}Bike {{ nickname }} has been successfully deleted from the portal.
+
+You can add more bikes by visiting:
+
+{{ bike_list_url }}
+
+{% endblocktrans %}

--- a/smbportal/templates/vehicles/mail/bike_deleted_subject.txt
+++ b/smbportal/templates/vehicles/mail/bike_deleted_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{{ site_name }} - {% blocktrans%}Bike {{ nickname }} has been deleted{% endblocktrans %}

--- a/smbportal/vehicles/apps.py
+++ b/smbportal/vehicles/apps.py
@@ -8,8 +8,26 @@
 #
 #########################################################################
 
+import uuid
+
 from django.apps import AppConfig
+from django.db.models.signals import post_delete
+from django.db.models.signals import post_save
 
 
 class VehiclesConfig(AppConfig):
     name = "vehicles"
+
+    def ready(self):
+        from . import signals
+        from . import models
+        post_save.connect(
+            signals.notify_bike_created,
+            sender=models.Bike,
+            dispatch_uid=str(uuid.uuid4())
+        )
+        post_delete.connect(
+            signals.notify_bike_deleted,
+            sender=models.Bike,
+            dispatch_uid=str(uuid.uuid4())
+        )

--- a/smbportal/vehicles/signals.py
+++ b/smbportal/vehicles/signals.py
@@ -1,0 +1,60 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+import logging
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.mail import send_mail
+from django.shortcuts import reverse
+from django.template.loader import render_to_string
+
+logger = logging.getLogger(__name__)
+
+
+def notify_bike_created(sender, **kwargs):
+    if kwargs.get("created"):
+        bike = kwargs.get("instance")
+        current_site = Site.objects.get_current()
+        context = {
+            "nickname": bike.nickname,
+            "site_name": current_site.name,
+            "bike_url": "https://{}{}".format(
+                current_site.domain, bike.get_absolute_url())
+        }
+        send_mail(
+            subject=render_to_string(
+                "vehicles/mail/bike_created_subject.txt", context=context),
+            message=render_to_string(
+                "vehicles/mail/bike_created_message.txt", context=context),
+            from_email=settings.MAIL_SENDER_ADDRESS,
+            recipient_list=[bike.owner.email]
+        )
+
+
+def notify_bike_deleted(sender, **kwargs):
+    bike = kwargs.get("instance")
+    current_site = Site.objects.get_current()
+    context = {
+        "nickname": bike.nickname,
+        "site_name": current_site.name,
+        "bike_list_url": "https://{}{}".format(
+            current_site.domain,
+            reverse("bikes:list")
+        )
+    }
+    send_mail(
+        subject=render_to_string(
+            "vehicles/mail/bike_deleted_subject.txt", context=context),
+        message=render_to_string(
+            "vehicles/mail/bike_deleted_message.txt", context=context),
+        from_email=settings.MAIL_SENDER_ADDRESS,
+        recipient_list=[bike.owner.email]
+    )

--- a/tests/integrationtests/test_api.py
+++ b/tests/integrationtests/test_api.py
@@ -156,12 +156,6 @@ def test_privileged_user_can_add_new_bike_observation(api_client,
             "pk": bike_owned_by_end_user.pk
         }
     )
-    reporter_url = reverse(
-        "api:users-detail",
-        kwargs={
-            "pk": str(bike_owned_by_end_user.owner.keycloak.UID)
-        }
-    )
     api_client.force_authenticate(user=privileged_user)
     response = api_client.post(
         reverse("api:bike-observations-list"),
@@ -173,9 +167,11 @@ def test_privileged_user_can_add_new_bike_observation(api_client,
             },
             "properties": {
                 "bike": bike_url,
-                "reporter": reporter_url,
+                "reporter_id": "fake_id",
+                "reporter_type": "fake_type",
             }
         },
         format="json"
     )
+    print(response.json())
     assert response.status_code == 201

--- a/tests/integrationtests/test_api_filters.py
+++ b/tests/integrationtests/test_api_filters.py
@@ -59,7 +59,7 @@ def test_bikeobservationfilterset_with_id(bike_owned_by_end_user,
     for address in addresses:
         vehiclemonitor.models.BikeObservation.objects.create(
             bike=bike_owned_by_end_user,
-            reporter=privileged_user,
+            reporter_id=privileged_user.pk,
             address=address
         )
     filter_set = filters.BikeObservationFilterSet(

--- a/tests/integrationtests/test_profiles_forms_integration.py
+++ b/tests/integrationtests/test_profiles_forms_integration.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.integration
     {
         "age": models.EndUserProfile.AGE_OLDER_THAN_SIXTY_FIVE,
         "gender": models.EndUserProfile.FEMALE_GENDER,
+        "occupation": models.EndUserProfile.OCCUPATION_UNEMPLOYED,
     }
 ])
 @pytest.mark.django_db


### PR DESCRIPTION
This PR adds email notifications for:

- user profile creation
- bike registration
- bike deletion

E-mail subject and description are controlled via templates. The proposed implementation makes use of django's signals framework by listening to the `post_save` and `post_delete` signals.

There are some extra notable changes that deal with the usage of TLS (AKA SSL):

 - The `django-sslserver` package is added as a dev dependency in order to promote using an SSL enabled test server when working on the code
- The `settings.SECURE_SSL_REDIRECT` has been activated. This causes django to redirect all `http` requests to `https`
- The `smbportal/base/settings/dev.py` module was introduced in order to allow tests to run without this SSL redirection. In addition, the `setup.cfg` file now uses these settings for running tests automatically. Tests can still be run with

  ```
  DJANGO_DATABASE_URL="postgis://<test_user>:<test_user_password>@localhost:5432/save-my-bike" pytest --flake8 -x
  ```

fixes #74