### PR TITLE
push `accept terms` button to end of form

### DIFF
--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -191,8 +191,6 @@ IPWARE = {
     "proxy_count": 1,
 }
 
-SECURE_SSL_REDIRECT = False
-
 LANGUAGES = (
     ("en", _("English")),
     ("it", _("Italian")),
@@ -219,13 +217,13 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
 ]
 
-EMAIL_HOST = "smtp.geo-solutions.it"
-EMAIL_PORT = 587
+EMAIL_HOST = get_environment_variable(
+    "DJANGO_EMAIL_HOST", "smtp.geo-solutions.it")
+EMAIL_USE_SSL = get_boolean_env_value("DJANGO_EMAIL_USE_SSL", "false")
+EMAIL_PORT = int(get_environment_variable("DJANGO_EMAIL_PORT", "587"))
 EMAIL_HOST_USER = get_environment_variable("DJANGO_EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = get_environment_variable("DJANGO_EMAIL_HOST_PASSWORD")
-
-MAIL_SENDER_ADDRESS = get_environment_variable(
-    "DJANGO_EMAIL_SENDER", default_value=EMAIL_HOST_USER)
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 BREADCRUMBS_TEMPLATE = "base/breadcrumbs.html"
 

--- a/smbportal/base/settings/dev.py
+++ b/smbportal/base/settings/dev.py
@@ -16,8 +16,6 @@ INSTALLED_APPS.extend([
     "sslserver",
 ])
 
-SECURE_SSL_REDIRECT = True
-
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/smbportal/base/utils.py
+++ b/smbportal/base/utils.py
@@ -47,6 +47,6 @@ def send_email_to_admins(subject_template, message_template, context=None):
     mail.send_mail(
         subject=render_to_string(subject_template, context=ctx),
         message=render_to_string(message_template, context=ctx),
-        from_email=settings.MAIL_SENDER_ADDRESS,
+        from_email=settings.DEFAULT_FROM_EMAIL,
         recipient_list=list(unique_recipients)
     )

--- a/smbportal/profiles/signals.py
+++ b/smbportal/profiles/signals.py
@@ -44,6 +44,6 @@ def notify_profile_created(sender, **kwargs):
                 "profiles/mail/profile_created_subject.txt", context=context),
             message=render_to_string(
                 "profiles/mail/profile_created_message.txt", context=context),
-            from_email=settings.MAIL_SENDER_ADDRESS,
+            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[user.email]
         )

--- a/smbportal/static/profiles/js/profile-create.js
+++ b/smbportal/static/profiles/js/profile-create.js
@@ -5,4 +5,18 @@ document.addEventListener('DOMContentLoaded', function () {
   acceptTosCheckBox.addEventListener('change', function () {
     submitBtn.disabled = !acceptTosCheckBox.checked
   })
+  // This is a hack to move the `accepted_terms_of_service` checkbox to the
+  // bottom of the form. It works by moving the element to the end of the form
+  // and then moving also the submit button to the end.
+  //
+  // This hack is here because django is autogenerating the markup for this
+  // page and it is using three different forms. The
+  // `accepted_terms_of_service` checkbox is part of the `user` form, which is
+  // the first to be rendered.
+  if (window.location.pathname.split('/').pop() === 'create') {
+    const acceptTosCheckBoxParent = acceptTosCheckBox.parentNode.parentNode.parentNode
+    const formElement = acceptTosCheckBoxParent.parentNode
+    formElement.appendChild(acceptTosCheckBoxParent)
+    formElement.appendChild(submitBtn)
+  }
 })

--- a/smbportal/vehicles/signals.py
+++ b/smbportal/vehicles/signals.py
@@ -34,7 +34,7 @@ def notify_bike_created(sender, **kwargs):
                 "vehicles/mail/bike_created_subject.txt", context=context),
             message=render_to_string(
                 "vehicles/mail/bike_created_message.txt", context=context),
-            from_email=settings.MAIL_SENDER_ADDRESS,
+            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[bike.owner.email]
         )
 
@@ -55,6 +55,6 @@ def notify_bike_deleted(sender, **kwargs):
             "vehicles/mail/bike_deleted_subject.txt", context=context),
         message=render_to_string(
             "vehicles/mail/bike_deleted_message.txt", context=context),
-        from_email=settings.MAIL_SENDER_ADDRESS,
+        from_email=settings.DEFAULT_FROM_EMAIL,
         recipient_list=[bike.owner.email]
     )

--- a/tests/unittests/test_base_utils.py
+++ b/tests/unittests/test_base_utils.py
@@ -29,7 +29,7 @@ def test_send_email_to_admins(mock_render_to_string, mock_django_mail,
     sender_address = "sender@mail.com"
     recipient_address = "receiver@mail.com"
     settings.ADMINS = []
-    settings.MAIL_SENDER_ADDRESS = sender_address
+    settings.DEFAULT_FROM_EMAIL = sender_address
 
     mocked_qs = mock.MagicMock(spec=django_user_model.objects)
     mocked_qs.filter.return_value = mocked_qs


### PR DESCRIPTION
This PR moves the `accept terms of service` checkbox to the end of the form in order to make it more consistent.

Implementation adds a bit of javascript hackery in order to move the checkbox after the page has been rendered by the server. This was needed because django is currently responsible for rendering form fields and the profile page actually features three different forms. The `accept terms` checkbox is located on the first form.

This PR also:
- enables some django related email settings to be added via environment variables;
- removes the previous SSL related redirection that was being done by django. This responsibility is now pushed to the web server instead