### PR TITLE
Api fixes

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -36,7 +36,7 @@ class SmbUserHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
         return reverse(
             view_name,
             kwargs={
-                "pk": obj.keycloak.UID
+                "uuid": obj.keycloak.UID
             },
             request=request,
             format=format
@@ -55,7 +55,7 @@ class SmbUserHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
         return reverse(
             view_name,
             kwargs={
-                "pk": obj.keycloak.UID
+                "uuid": obj.keycloak.UID
             },
             request=request,
             format=format
@@ -72,11 +72,11 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
     url = SmbUserHyperlinkedIdentityField(
         view_name="api:users-detail",
     )
-    id = serializers.SerializerMethodField()
+    uuid = serializers.SerializerMethodField()
     profile = serializers.SerializerMethodField()
     profile_type = serializers.SerializerMethodField()
 
-    def get_id(self, obj):
+    def get_uuid(self, obj):
         return obj.keycloak.UID
 
     def get_profile(self, obj):
@@ -87,12 +87,10 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
                 profiles.models.PrivilegedUserProfile: (
                     PrivilegedUserProfileSerializer),
             }.get(profile_class)
-            logger.debug("serializer_class: {}".format(serializer_class))
             serializer = serializer_class(
                 instance=obj.profile,
                 context=self.context
             )
-            logger.debug("serializer: {}".format(serializer))
             result = serializer.data
         else:
             result = None
@@ -105,14 +103,47 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
         model = profiles.models.SmbUser
         fields = (
             "url",
-            "id",
+            "uuid",
             "username",
             "email",
+            "date_joined",
+            "language_preference",
             "first_name",
             "last_name",
             "nickname",
             "profile",
             "profile_type",
+        )
+
+
+class UserDumpSerializer(SmbUserSerializer):
+    """Produce a User, its vehicles and Tags"""
+
+    vehicles = serializers.SerializerMethodField()
+
+    def get_vehicles(self, obj):
+        serializer = BikeDetailSerializer(
+            instance=obj.bikes.all(),
+            many=True,
+            context=self.context
+        )
+        return serializer.data
+
+    class Meta:
+        model = profiles.models.SmbUser
+        fields = (
+            "url",
+            "uuid",
+            "username",
+            "email",
+            "date_joined",
+            "language_preference",
+            "first_name",
+            "last_name",
+            "nickname",
+            "profile",
+            "profile_type",
+            "vehicles"
         )
 
 

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -116,18 +116,12 @@ class SmbUserViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class BikeViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = serializers.BikeDetailSerializer
     queryset = vehicles.models.Bike.objects.all()
     required_permissions = (
         "vehicles.can_list_bikes",
     )
     filter_class = filters.BikeFilterSet
-
-    def get_serializer_class(self):
-        if self.action == "retrieve":
-            serializer_class = serializers.BikeDetailSerializer
-        else:
-            serializer_class = serializers.BikeListSerializer
-        return serializer_class
 
 
 # TODO: should external users be allowed to delete existing tags?

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -12,8 +12,10 @@ import logging
 
 from django_filters.rest_framework import DjangoFilterBackend
 import photologue.models
+from rest_framework.decorators import action
 from rest_framework import mixins
 from rest_framework import viewsets
+from rest_framework.response import Response
 from rest_framework_gis.pagination import GeoJsonPagination
 
 import profiles.models
@@ -110,9 +112,32 @@ class SmbUserViewSet(viewsets.ReadOnlyModelViewSet):
     required_permissions = (
         "profiles.can_list_users",
     )
+    lookup_field = "uuid"
 
     def get_object(self):
-        return self.get_queryset().get(keycloak__UID=self.kwargs["pk"])
+        obj = self.get_queryset().get(keycloak__UID=self.kwargs["uuid"])
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+    @action(detail=True)
+    def single_dump(self, request, uuid=None):
+        user = self.get_object()
+        serializer = serializers.UserDumpSerializer(
+            instance=user,
+            context={"request": request}
+        )
+        return Response(serializer.data)
+
+    @action(detail=False)
+    def dump(self, request):
+        qs = self.filter_queryset(self.get_queryset())
+        paginated_qs = self.paginate_queryset(qs)
+        serializer = serializers.UserDumpSerializer(
+            instance=paginated_qs,
+            many=True,
+            context=self.get_serializer_context(),
+        )
+        return self.get_paginated_response(serializer.data)
 
 
 class BikeViewSet(viewsets.ReadOnlyModelViewSet):

--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -238,7 +238,10 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_FILTER_BACKENDS": (
         "django_filters.rest_framework.DjangoFilterBackend",
-    )
+    ),
+    "DEFAULT_PAGINATION_CLASS": (
+        "rest_framework.pagination.PageNumberPagination"),
+    "PAGE_SIZE": 20,
 }
 
 AVATAR_AUTO_GENERATE_SIZES = (

--- a/smbportal/profiles/models.py
+++ b/smbportal/profiles/models.py
@@ -41,6 +41,11 @@ class SmbUser(AbstractUser):
         default=False
     )
 
+    class Meta:
+        ordering = [
+            "date_joined",
+        ]
+
     @property
     def profile(self):
         attribute_names = (

--- a/smbportal/vehicles/models.py
+++ b/smbportal/vehicles/models.py
@@ -188,6 +188,9 @@ class Bike(Vehicle):
 
     class Meta:
         unique_together = ("owner", "nickname")
+        ordering = [
+            "id",
+        ]
 
     def __str__(self):
         return "{0.nickname}".format(self)
@@ -275,6 +278,11 @@ class PhysicalTag(models.Model):
         _("creation date"),
         auto_now_add=True
     )
+
+    class Meta:
+        ordering = [
+            "creation_date",
+        ]
 
 
 class BikePicture(Photo):

--- a/tests/unittests/test_api_serializers.py
+++ b/tests/unittests/test_api_serializers.py
@@ -23,7 +23,7 @@ def test_smbuserhyperlinkedidentityfield_returns_uuid(api_request_factory,
                                                       mocked_user):
     fake_uuid = "fake_uuid"
     fake_request = api_request_factory.get(
-        reverse("api:users-detail", kwargs={"pk": fake_uuid}))
+        reverse("api:users-detail", kwargs={"uuid": fake_uuid}))
     user_detail_view_name = "api:users-detail"
     field = serializers.SmbUserHyperlinkedIdentityField(
         view_name=user_detail_view_name,
@@ -71,7 +71,7 @@ def test_smbuserserializer_returns_uuid(api_request_factory, mocked_user):
 
     fake_uuid = "fake uuid"
     fake_request = api_request_factory.get(
-        reverse("api:users-detail", kwargs={"pk": fake_uuid}))
+        reverse("api:users-detail", kwargs={"uuid": fake_uuid}))
     mocked_user.keycloak.return_value = mock.MagicMock(spec=Keycloak)
     mocked_user.keycloak.UID = fake_uuid
     mocked_user.profile = None
@@ -80,4 +80,4 @@ def test_smbuserserializer_returns_uuid(api_request_factory, mocked_user):
         context={"request": fake_request}
     )
     serializer_data = serializer.data
-    assert serializer_data["id"] == fake_uuid
+    assert serializer_data["uuid"] == fake_uuid


### PR DESCRIPTION
This PR relates to the following:

- fixes #100 
- fixes #99 

There are now two new endpoints `/users/dump` and `/users/{uuid}/single_dump`. These provide extended user information (as was present in the old API), namely:

- A user's vehicles
- for each vehicle:
  - A list with picture URLs
  - A list with tags
  - current status

Example response from a request to `/users/dump` showing a single user's data:

```
[
  {
    "url": "http://10.0.1.164:8000/api/users/db92e41c-c7bc-4423-a242-a71fca14d351/",
    "uuid": "db92e41c-c7bc-4423-a242-a71fca14d351",
    "username": "tester1",
    "email": "ricardo.garcia.silva@gmail.com",
    "date_joined": "2018-05-25T20:48:17.816636Z",
    "language_preference": "en",
    "first_name": "Tester1",
    "last_name": "Doe",
    "nickname": "dread",
    "profile": {
      "gender": "male",
      "age": "30 - 65",
      "phone_number": "+351966361147",
      "bio": "This is it so deal with it ya hear?",
      "date_updated": "2018-07-11T21:45:34.551948Z",
      "occupation": "engineer"
    },
    "profile_type": "enduserprofile",
    "vehicles": [
      {
        "url": "http://10.0.1.164:8000/api/bikes/79522305-c6fb-46bf-bdcb-435d1866b0be/",
        "id": "79522305-c6fb-46bf-bdcb-435d1866b0be",
        "owner": "http://10.0.1.164:8000/api/users/db92e41c-c7bc-4423-a242-a71fca14d351/",
        "picture_gallery": "http://10.0.1.164:8000/api/picture-galleries/35/",
        "pictures": [
          "http://10.0.1.164:8000/media/photologue/photos/61xd6-xh8ZL._SX466__FUtTCPr.jpg"
        ],
        "tags": [
          "http://10.0.1.164:8000/api/tags/5/"
        ],
        "last_update": "2018-06-26T14:19:52.582878Z",
        "bike_type": "foldable",
        "gear": "groupset above 18 speeds",
        "brake": "disk",
        "nickname": "champione",
        "brand": "",
        "model": "",
        "color": "",
        "saddle": "",
        "has_basket": false,
        "has_cargo_rack": false,
        "has_bags": true,
        "other_details": "",
        "current_status": {
          "url": "http://10.0.1.164:8000/api/bike-statuses/89/",
          "lost": true
        }
      },
      {
        "url": "http://10.0.1.164:8000/api/bikes/7196bdb5-5c24-4477-8ce7-4b4870014923/",
        "id": "7196bdb5-5c24-4477-8ce7-4b4870014923",
        "owner": "http://10.0.1.164:8000/api/users/db92e41c-c7bc-4423-a242-a71fca14d351/",
        "picture_gallery": "http://10.0.1.164:8000/api/picture-galleries/36/",
        "pictures": [
          "http://10.0.1.164:8000/media/photologue/photos/i_are_programmer.jpg",
          "http://10.0.1.164:8000/media/photologue/photos/Screenshot_from_2016-07-05_01-40-41.png",
          "http://10.0.1.164:8000/media/photologue/photos/image20151030_200128696.jpg",
          "http://10.0.1.164:8000/media/photologue/photos/Snapshot_20090126_4.jpg",
          "http://10.0.1.164:8000/media/photologue/photos/GOPR4391.JPG"
        ],
        "tags": [],
        "last_update": "2018-06-19T21:30:18.625638Z",
        "bike_type": "city",
        "gear": "groupset above 18 speeds",
        "brake": "disk",
        "nickname": "gonzalez",
        "brand": "",
        "model": "",
        "color": "",
        "saddle": "",
        "has_basket": false,
        "has_cargo_rack": false,
        "has_bags": false,
        "other_details": "",
        "current_status": {
          "url": "http://10.0.1.164:8000/api/bike-statuses/34/",
          "lost": true
        }
      },
    ]
  }
]
```

Also included in this PR:

- API endpoints are now paginated. I've set `PAGE_SIZE = 20`, but this might require tweaking later on
- Most relevant models now explicitly include the `ordering` attribute on their respective `Meta` classes so that they are paginated in a consistent manner