### PR TITLE
added DELETE to some endpoints

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -261,6 +261,12 @@ class PhysicalTagSerializer(serializers.ModelSerializer):
         slug_field="short_uuid",
         queryset=vehicles.models.Bike.objects.all()
     )
+    bike_url = serializers.HyperlinkedRelatedField(
+        source="bike",
+        read_only=True,
+        view_name="api:bikes-detail",
+        lookup_field="short_uuid",
+    )
 
     class Meta:
         model = vehicles.models.PhysicalTag
@@ -269,6 +275,7 @@ class PhysicalTagSerializer(serializers.ModelSerializer):
             "id",
             "epc",
             "bike",
+            "bike_url",
             "creation_date",
         )
 
@@ -370,10 +377,15 @@ class BikeObservationSerializer(GeoFeatureModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="api:bike-observations-detail",
     )
-    bike = serializers.HyperlinkedRelatedField(
+    bike = serializers.SlugRelatedField(
+        slug_field="short_uuid",
+        queryset=vehicles.models.Bike.objects.all()
+    )
+    bike_url = serializers.HyperlinkedRelatedField(
+        source="bike",
+        read_only=True,
         view_name="api:bikes-detail",
         lookup_field="short_uuid",
-        queryset=vehicles.models.Bike.objects.all()
     )
 
     class Meta:
@@ -383,6 +395,7 @@ class BikeObservationSerializer(GeoFeatureModelSerializer):
             "url",
             "id",
             "bike",
+            "bike_url",
             "reporter_id",
             "reporter_type",
             "reporter_name",

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -153,7 +153,7 @@ class BikeViewSet(viewsets.ReadOnlyModelViewSet):
 
 # TODO: should external users be allowed to delete existing tags?
 class PhysicalTagViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
-                         mixins.CreateModelMixin,  # mixins.DestroyModelMixin,
+                         mixins.CreateModelMixin,  mixins.DestroyModelMixin,
                          viewsets.GenericViewSet):
     serializer_class = serializers.PhysicalTagSerializer
     queryset = vehicles.models.PhysicalTag.objects.all()
@@ -200,7 +200,8 @@ class PictureViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class BikeObservationViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
-                             mixins.CreateModelMixin, viewsets.GenericViewSet):
+                             mixins.CreateModelMixin, mixins.DestroyModelMixin,
+                             viewsets.GenericViewSet):
     serializer_class = serializers.BikeObservationSerializer
     required_permissions = (
         "vehiclemonitor.can_list_bike_observation",

--- a/tests/integrationtests/test_api.py
+++ b/tests/integrationtests/test_api.py
@@ -150,12 +150,6 @@ def test_privileged_can_filter_bikes_using_tag_epc(api_client,
 def test_privileged_user_can_add_new_bike_observation(api_client,
                                                       privileged_user,
                                                       bike_owned_by_end_user):
-    bike_url = reverse(
-        "api:bikes-detail",
-        kwargs={
-            "short_uuid": bike_owned_by_end_user.short_uuid
-        }
-    )
     api_client.force_authenticate(user=privileged_user)
     response = api_client.post(
         reverse("api:bike-observations-list"),
@@ -166,7 +160,7 @@ def test_privileged_user_can_add_new_bike_observation(api_client,
                 "coordinates": [0, 0]
             },
             "properties": {
-                "bike": bike_url,
+                "bike": bike_owned_by_end_user.short_uuid,
                 "reporter_id": "fake_id",
                 "reporter_type": "fake_type",
             }


### PR DESCRIPTION
This PR adds support for `HTTP DELETE` for the following endpoints:

- `/api/tags`
- `/api/bike-observations`

For example, for deleting a tag, send the following request

```
curl -X DELETE "http://10.0.1.164:8000/api/tags/{tag-id}/" -H  "accept: application/json" -H "Authentication: Bearer {token}"
```


It also includes some changes in the serializers:

- `BikeObservationSerializer.bike` now shows the bike's short uuid instead of the URL. A new `bike_url` field has been added which still shows the URL (this field is readonly)

  Creating a new observation can be done like this:

  ```
  POST /api/bike-observations

  {
      "type": "Feature",
      "geometry": {
        "coordinates": [
          12.318603515624996,
          42.17825555111266
        ],
        "type": "Point"
      },
      "properties": {
        "bike": "GkxGUGez",
        "reporter_id": "placeholder_id",
        "reporter_type": "placeholder_type",
        "reporter_name": "placeholder_name"
      }
  }
  ```

- `PhysicalTagSerializer` also has a new `bike_url` field (in addition to the already existing `bike` field), which shows the bike URL.


fixes #108
fixes #107