### PR TITLE
made `epc` be the lookup field for Tags

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -180,7 +180,8 @@ class BikeListSerializer(serializers.HyperlinkedModelSerializer):
     tags = serializers.HyperlinkedRelatedField(
         view_name="api:tags-detail",
         many=True,
-        read_only=True
+        read_only=True,
+        lookup_field="epc"
     )
     current_status = serializers.SerializerMethodField()
 
@@ -255,7 +256,7 @@ class PhysicalTagSerializer(serializers.ModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="api:tags-detail",
         lookup_field="epc",
-        lookup_url_kwarg="pk",
+        lookup_url_kwarg="epc",
     )
     bike = serializers.SlugRelatedField(
         slug_field="short_uuid",
@@ -272,7 +273,6 @@ class PhysicalTagSerializer(serializers.ModelSerializer):
         model = vehicles.models.PhysicalTag
         fields = (
             "url",
-            "id",
             "epc",
             "bike",
             "bike_url",

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -161,6 +161,7 @@ class PhysicalTagViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         "vehicles.can_list_physical_tags",
         "vehicles.can_create_physical_tag",
     )
+    lookup_field = "epc"
 
 
 class BikeStatusViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
This PR makes `epc` the lookup attribute for tags in the API. Since `epc` is already enforced to be unique, the `id` field is removed from the API (remaining private).

Example usage of the tags endpoints:

```
# List all tags
GET /api/tags

  "count": 2,
  "next": null,
  "previous": null,
  "results": [
    {
      "url": "http://10.0.1.164:8000/api/tags/bla123/",
      "epc": "bla123",
      "bike": "R2GzTbt6",
      "bike_url": "http://10.0.1.164:8000/api/bikes/R2GzTbt6/",
      "creation_date": "2018-07-18T17:26:55.397325Z"
    },
    {
      "url": "http://10.0.1.164:8000/api/tags/2232/",
      "epc": "2232",
      "bike": "R2GzTbt6",
      "bike_url": "http://10.0.1.164:8000/api/bikes/R2GzTbt6/",
      "creation_date": "2018-07-23T08:20:23.857737Z"
    }
  ]
}


# Show a single tag
GET /api/tags/2232

{
  "url": "http://10.0.1.164:8000/api/tags/2232/",
  "epc": "2232",
  "bike": "R2GzTbt6",
  "bike_url": "http://10.0.1.164:8000/api/bikes/R2GzTbt6/",
  "creation_date": "2018-07-23T08:20:23.857737Z"
}


# Create a new tag
POST /api/tags/some-123456-epc

{
  "epc": "some-123456-epc",
  "bike": "R2GzTbt6"
}


# Delete an existing tag
DELETE /api/tags/some-123456-epc
```

fixes #111