### PR TITLE
updated and pinned oidc dependencies

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,9 +17,8 @@ requests==2.18.4
 rules==1.3
 shortuuid==0.5.0
 
-git+https://github.com/jhuapl-boss/django-oidc.git
-git+https://github.com/jhuapl-boss/drf-oidc-auth.git
+git+https://github.com/jhuapl-boss/django-oidc.git@v1.1.0
+git+https://github.com/jhuapl-boss/drf-oidc-auth.git@v0.8.0
 
-# fork of boss-oidc, while the project does not merge
-# https://github.com/jhuapl-boss/boss-oidc/pull/20
-git+https://github.com/geosolutions-it/boss-oidc.git
+# includes a fix for jhuapl-boss/boss-oidc #28
+git+https://github.com/geosolutions-it/boss-oidc.git@4fad0f8579f4c091b8a80426407cad7d98969e28


### PR DESCRIPTION
This PR updates the oidc dependencies to their latest versions

Since the upstream does not provide packages on pypi, we pull the code from github. Pinned tags in order to get reproducible installs.

While updating these packages the `boss-oidc` package was found to have a [bug](https://github.com/jhuapl-boss/boss-oidc/issues/28). This bug made the `boss-oidc/migrations` directory be excluded from installs and prevented proper usage of the package. I've fixed and PR'd the change to upstream and also applied to our `geosolutions-it/boss-oidc` fork. As such, the fork is used in this PR in order to make automatic installs work OK.