### PR TITLE
added API endpoints for creating and deleting users

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -75,6 +75,7 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
     uuid = serializers.SerializerMethodField()
     profile = serializers.SerializerMethodField()
     profile_type = serializers.SerializerMethodField()
+    password = serializers.CharField(write_only=True)
 
     def get_uuid(self, obj):
         return obj.keycloak.UID
@@ -105,6 +106,7 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
             "url",
             "uuid",
             "username",
+            "password",
             "email",
             "date_joined",
             "language_preference",

--- a/smbportal/keycloakauth/keycloakadmin.py
+++ b/smbportal/keycloakauth/keycloakadmin.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 _REQUEST_HANDLERS = {
     "get": requests.get,
     "post": requests.post,
-    "put": requests.put
+    "put": requests.put,
+    "delete": requests.delete,
 }
 
 
@@ -229,6 +230,13 @@ class KeycloakManager(object):
                 "Content-Type": "application/json"
             }
         )
+
+    def delete_user(self, user_id):
+        self.keycloak_client.make_request(
+            "/users/{id}".format(id=user_id),
+            http_method="delete"
+        )
+
 
     def get_groups(self):
         """Get representation of groups associated with the keycloak realm"""

--- a/smbportal/keycloakauth/utils.py
+++ b/smbportal/keycloakauth/utils.py
@@ -1,0 +1,73 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+import logging
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from bossoidc.models import Keycloak
+from requests.exceptions import HTTPError
+
+from base.utils import get_group_name
+
+logger = logging.getLogger(__name__)
+
+
+def create_user(username, email, password, group_path, keycloak_manager,
+                profile_model=None, profile_kwargs=None):
+    """Create a new user on keycloak and on django DB"""
+    user_id = create_keycloak_user(keycloak_manager, username, email,
+                                   password, group_path)
+    django_user = create_django_user(
+        username, email, user_id, get_group_name(group_path),
+        user_profile_model=profile_model,
+        user_profile_kwargs=profile_kwargs
+    )
+    return django_user
+
+
+def delete_user(username, keycloak_manager):
+    """Delete user from django and from keycloak"""
+
+    user = get_user_model().objects.get(username=username)
+    keycloak_id = user.keycloak.UID
+    try:
+        keycloak_manager.delete_user(keycloak_id)
+    except HTTPError as exc:
+        logger.warning("Could not delete user {!r} from keycloak. Reason: "
+                       "{}".format(keycloak_id, str(exc)))
+    user.delete()
+
+
+def create_keycloak_user(keycloak_manager, username, email,
+                         password, group_path):
+    """Create a user on keycloak and assign it the specified group"""
+    keycloak_manager.create_user(username, email=email, password=password)
+    user_id = keycloak_manager.get_user_details(username)["id"]
+    keycloak_manager.add_user_to_group(user_id, group_path)
+    return user_id
+
+
+def create_django_user(username, email, keycloak_id, group_name,
+                       user_profile_model=None, user_profile_kwargs=None):
+    """Create a new django user and setup its keycloak id and groups"""
+    user = get_user_model().objects.create(
+        username=username, email=email)
+    Keycloak.objects.create(user=user, UID=keycloak_id)
+    group = Group.objects.get_or_create(name=group_name)[0]
+    group.user_set.add(user)
+    group.save()
+    if user_profile_model is not None:
+        kwargs = user_profile_kwargs if user_profile_kwargs is not None else {}
+        user_profile_model.objects.create(
+            user=user,
+            **kwargs
+        )
+    return user

--- a/smbportal/profiles/rules.py
+++ b/smbportal/profiles/rules.py
@@ -36,11 +36,17 @@ def has_profile(user):
     return bool(user.profile) if user.is_authenticated else False
 
 
+@rules.predicate
+def is_admin(user):
+    return user.is_superuser
+
+
 is_end_user = rules.is_group_member("end_users")
 is_privileged_user = rules.is_group_member("privileged_users")
 
 for perm, predicate in {
     "can_list_users": is_privileged_user,
+    "can_delete_user": is_admin,
     "can_create_profile": ~has_profile,
     "can_view_profile": has_profile,
     "can_edit_profile": has_profile & is_profile_owner,


### PR DESCRIPTION
This PR adds two new API endpoints for dealing with user creation and deletion. These endpoints are only available to portal admins (i.e. users that belong to the group `/portal_admins` on keycloak).

Users are created/deleted from both the portal DB and keycloak.

These endpoints are especially useful for setting up automated acceptance tests.

### Creating new end users

```
POST /api/users/create_end_user

{
  "username": "test-user1",
  "password": "123456",
  "email": "testuser1@example.com",
  "first_name": "Test",
  "last_name": "User1"
}
```

### Deleting users

```
DELETE /api/users/{uuid}
```

