### PR TITLE
removed django-sslserver dependency

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,5 @@
 --requirement production.txt
 
-django-sslserver==0.20
 flake8==3.5.0
 pytest==3.6.0
 pytest-django==3.2.1

--- a/smbportal/base/settings/dev.py
+++ b/smbportal/base/settings/dev.py
@@ -12,10 +12,6 @@
 
 from .base import *
 
-INSTALLED_APPS.extend([
-    "sslserver",
-])
-
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,


### PR DESCRIPTION
This PR removes the django-sslserver stuff.

With the move to a dedicated public instance for dev, I'm moving also my own private dev environment to a similar setup. This means django-sslserver is not needed anymore