### PR TITLE
added missing lxml dependency

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,6 +10,7 @@ django-ipware==2.1.0
 django-photologue==3.8.1
 drf-yasg==1.8.0
 geoip2==2.9.0
+lxml==4.2.3
 psycopg2-binary==2.7.4
 pygdal==2.2.3.3 # depends on libgdal-dev 2.3.3
 pytz==2018.4


### PR DESCRIPTION
This PR adds a missing dependency on `lxml`. This library is used in the `populatetracks` management script