### PR TITLE
api my-* redirects to wrong endpoints

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -240,10 +240,6 @@ class BikeListSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class BikeDetailSerializer(BikeListSerializer):
-    picture_gallery = serializers.HyperlinkedRelatedField(
-        view_name="api:picture-galleries-detail",
-        read_only=True
-    )
     pictures = serializers.SerializerMethodField()
 
     def get_pictures(self, bike):
@@ -260,7 +256,6 @@ class BikeDetailSerializer(BikeListSerializer):
             "url",
             "short_uuid",
             "owner",
-            "picture_gallery",
             "pictures",
             "tags",
             "last_update",
@@ -315,7 +310,6 @@ class MyBikeDetailSerializer(BikeDetailSerializer):
             "url",
             "short_uuid",
             "owner",
-            "picture_gallery",
             "pictures",
             "tags",
             "last_update",
@@ -462,22 +456,12 @@ class GallerySerializer(serializers.HyperlinkedModelSerializer):
 
 
 class PictureSerializer(serializers.HyperlinkedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name="api:pictures-detail",
-    )
-    galleries = serializers.HyperlinkedRelatedField(
-        view_name="api:picture-galleries-detail",
-        many=True,
-        read_only=True
-    )
 
     class Meta:
         model = photologue.models.Photo
         fields = (
-            "url",
             "id",
             "image",
-            "galleries",
         )
 
 

--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -429,6 +429,29 @@ class BikeStatusSerializer(GeoFeatureModelSerializer):
                 self.fields.pop(field_name)
 
 
+class MyBikeStatusSerializer(BikeStatusSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name="api:my-bike-statuses-detail",
+    )
+    bike = serializers.HyperlinkedRelatedField(
+        view_name="api:my-bikes-detail",
+        lookup_field="short_uuid",
+        queryset=vehicles.models.Bike.objects.all()
+    )
+
+    class Meta:
+        model = vehicles.models.BikeStatus
+        geo_field = "position"
+        fields = (
+            "url",
+            "id",
+            "bike",
+            "lost",
+            "creation_date",
+            "details",
+        )
+
+
 class GallerySerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="api:picture-galleries-detail",

--- a/smbportal/api/urls.py
+++ b/smbportal/api/urls.py
@@ -63,16 +63,6 @@ router.register(
     base_name="bike-statuses"
 )
 router.register(
-    prefix="picture-galleries",
-    viewset=views.GalleryViewSet,
-    base_name="picture-galleries"
-)
-router.register(
-    prefix="pictures",
-    viewset=views.PictureViewSet,
-    base_name="pictures"
-)
-router.register(
     prefix="bike-observations",
     viewset=views.BikeObservationViewSet,
     base_name="bike-observations"

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -65,7 +65,7 @@ class MyBikeViewSet(viewsets.ModelViewSet):
 
 
 class MyBikeObservationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
-    serializer_class = serializers.BikeObservationSerializer
+    serializer_class = serializers.MyBikeObservationSerializer
     required_permissions = (
         "vehiclemonitor.can_list_own_bike_observation",
     )
@@ -81,10 +81,11 @@ class MyBikeObservationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
 
 class MyPhysicalTagViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = serializers.PhysicalTagSerializer
+    serializer_class = serializers.MyPhysicalTagSerializer
     required_permissions = (
         "vehicles.can_list_own_physical_tags",
     )
+    lookup_field = "epc"
 
     def get_queryset(self):
         return vehicles.models.PhysicalTag.objects.filter(

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -12,7 +12,6 @@ import logging
 
 from django.conf import settings
 from django_filters.rest_framework import DjangoFilterBackend
-import photologue.models
 from rest_framework.decorators import action
 from rest_framework import mixins
 from rest_framework import viewsets
@@ -226,7 +225,6 @@ class BikeViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_field = "short_uuid"
 
 
-# TODO: should external users be allowed to delete existing tags?
 class PhysicalTagViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
                          mixins.CreateModelMixin,  mixins.DestroyModelMixin,
                          viewsets.GenericViewSet):
@@ -247,32 +245,6 @@ class BikeStatusViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return vehicles.models.BikeStatus.objects.all()
-
-
-class GalleryViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = serializers.GallerySerializer
-    required_permissions = (
-        "vehicles.can_list_bikes",
-    )
-    required_object_permissions = (
-        "vehicles.can_edit_bike",
-    )
-
-    def get_queryset(self):
-        return photologue.models.Gallery.objects.all()
-
-
-class PictureViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = serializers.PictureSerializer
-    required_permissions = (
-        "vehicles.can_list_bikes",
-    )
-    required_object_permissions = (
-        "vehicles.can_edit_bike",
-    )
-
-    def get_queryset(self):
-        return photologue.models.Photo.objects.all()
 
 
 class BikeObservationViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -93,7 +93,7 @@ class MyPhysicalTagViewSet(viewsets.ReadOnlyModelViewSet):
 
 class MyBikeStatusViewSet(mixins.ListModelMixin, mixins.CreateModelMixin,
                           mixins.RetrieveModelMixin, viewsets.GenericViewSet):
-    serializer_class = serializers.BikeStatusSerializer
+    serializer_class = serializers.MyBikeStatusSerializer
     required_permissions = (
         "vehicles.can_list_own_bike_status",
         "vehicles.can_create_own_bike_status",

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 class MyUserViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
                     viewsets.GenericViewSet):
-    serializer_class = serializers.SmbUserSerializer
+    serializer_class = serializers.MyUserSerializer
     required_permissions = (
         "profiles.can_view_profile",
     )
@@ -52,7 +52,7 @@ class MyUserViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
 
 
 class MyBikeViewSet(viewsets.ModelViewSet):
-    serializer_class = serializers.BikeDetailSerializer
+    serializer_class = serializers.MyBikeDetailSerializer
     required_permissions = (
         "vehicles.can_list_own_bikes",
         "vehicles.can_create_bike",

--- a/smbportal/templates/profiles/privilegeduserprofile_create.html
+++ b/smbportal/templates/profiles/privilegeduserprofile_create.html
@@ -13,42 +13,38 @@
     {% breadcrumb _("complete profile privileged user") 'profile:create' %}
 {% endblock %}
 
-{% block content %}
-    <div id="container">
-        <div class="container p-t-60">
-            <div class="row">
-                <div class="col-lg-2">
-                    <div class="user-info">
-                        <div class="user-avatar">
-                            <a class="edit-avatar" href="{% url 'avatar_change' %}"><i class="fa fa-pencil-square-o"></i></a>
-                            {% avatar user class="rounded-circle" %}
-                        </div>
-                        <div class="user-data">
-                            <h4>{{ user.first_name }} {{ user.last_name }}</h4>
-                            <span>
-                                <i class="fa fa-user-o"></i> {{ user.username }}<br>
-                                <i class="fa fa-envelope-o"></i> {{ user.email }}
-                            </span>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-10">
-                    <div class="card text-white bg-info text-center mb-3">
-                        <div class="card-body">
-                            <h4 class="card-title">{% trans "Note" %}</h4>
-                            <p class="card-text">{% blocktrans %}Registering as a privileged user requires manual authorization from one of the platform's administrators. Your application will be moderated and you will be notified via e-mail. Until then you will not be able to use the portal{% endblocktrans %}</p>
-                        </div>
-                    </div>
-                    <form method="post">
-                        {% csrf_token %}
-                        {{ user_form|crispy }}
-                        {{ form|crispy }}
-                        <a href="{% url 'profile:create' %}" class="btn btn-outline-secondary btn-lg"><i class="fa fa-hand-o-left"></i> {% trans "Go back" %}</a>
-                        <button type="submit" class="btn btn-primary">{% trans "Register as privileged user" %}</button>
-                    </form>
+{% block main %}
+    <div class="col-lg-2">
+        <div class="user-info">
+            <div class="user-avatar">
+                <a class="edit-avatar" href="{% url 'avatar_change' %}"><i class="fa fa-pencil-square-o"></i></a>
+                {% avatar user class="rounded-circle" %}
+            </div>
+            <div class="user-data">
+                <h4>{{ user.first_name }} {{ user.last_name }}</h4>
+                <span>
+                    <i class="fa fa-user-o"></i> {{ user.username }}<br>
+                    <i class="fa fa-envelope-o"></i> {{ user.email }}
+                </span>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-10">
+        <div class="col-lg">
+            <div class="card text-white bg-info text-center mb-3">
+                <div class="card-body">
+                    <h4 class="card-title">{% trans "Note" %}</h4>
+                    <p class="card-text">{% blocktrans %}Registering as a privileged user requires manual authorization from one of the platform's administrators. Your application will be moderated and you will be notified via e-mail. Until then you will not be able to use the portal{% endblocktrans %}</p>
                 </div>
             </div>
         </div>
+        <form method="post">
+            {% csrf_token %}
+            {{ user_form|crispy }}
+            {{ form|crispy }}
+            <a href="{% url 'profile:create' %}" class="btn btn-outline-secondary btn-lg"><i class="fa fa-hand-o-left"></i> {% trans "Go back" %}</a>
+            <button type="submit" class="btn btn-primary">{% trans "Register as privileged user" %}</button>
+        </form>
     </div>
 {% endblock %}
 

--- a/tests/acceptancetests/test_portal_acceptance.py
+++ b/tests/acceptancetests/test_portal_acceptance.py
@@ -39,6 +39,7 @@ def test_cookie_warning_contains_link_to_privacy_policy(browser, url):
 def test_cookie_warning_disappears_after_acceptance(browser, url):
     browser.visit(url)
     consent_div_selector = "[aria-label=cookieconsent]"
+    browser.is_element_present_by_css(consent_div_selector, wait_time=10)
     cookie_consent_div = browser.find_by_css(consent_div_selector)
     cookie_consent_accept_button = cookie_consent_div.find_by_css(
         ".cc-compliance > a")

--- a/tests/integrationtests/test_api.py
+++ b/tests/integrationtests/test_api.py
@@ -35,8 +35,6 @@ def test_end_user_can_access_list_endpoint(endpoint, api_client, end_user):
     "api:bike-statuses-list",
     "api:tags-list",
     "api:users-list",
-    "api:picture-galleries-list",
-    "api:pictures-list",
 ])
 @pytest.mark.django_db
 def test_end_user_cannot_access_list_endpoint(endpoint, api_client, end_user):
@@ -51,8 +49,6 @@ def test_end_user_cannot_access_list_endpoint(endpoint, api_client, end_user):
     "api:bike-statuses-list",
     "api:tags-list",
     "api:users-list",
-    "api:picture-galleries-list",
-    "api:pictures-list",
 ])
 def test_privileged_user_can_access_list_endpoint(endpoint, privileged_user,
                                                   api_client):

--- a/tests/integrationtests/test_api.py
+++ b/tests/integrationtests/test_api.py
@@ -73,7 +73,7 @@ def test_privileged_user_cannot_access_list_endpoint(endpoint, privileged_user,
 @pytest.mark.django_db
 def test_end_user_can_report_lost_bike(api_client, bike_owned_by_end_user):
     bike_url = reverse(
-        "api:bikes-detail",
+        "api:my-bikes-detail",
         kwargs={
             "short_uuid": bike_owned_by_end_user.short_uuid
         }

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -3,6 +3,8 @@ from unittest import mock
 import pytest
 from rest_framework.test import APIRequestFactory
 
+import profiles.models
+
 
 @pytest.fixture(scope="session")
 def api_request_factory():
@@ -15,3 +17,41 @@ def mocked_user():
     mocked_user_class = mock.MagicMock(
         spec="api.serializers.profiles.models.SmbUser")
     return mocked_user_class()
+
+
+@pytest.fixture
+def mocked_end_user(mocked_user, settings):
+    # this mock is created from an instance in order to make sure the mock
+    # is able to pass isinstance tests. For more info see:
+    # http://www.voidspace.org.uk/python/mock/mock.html#the-mock-class
+    # mocked_end_user_class = mock.MagicMock(
+    #     spec="profiles.models.EndUserProfile"
+    # )
+    mocked_group_class = mock.MagicMock(
+        spec="django.contrib.auth.models.Group")
+    mocked_group = mocked_group_class()
+    mocked_group.name = settings.END_USER_PROFILE
+    mocked_end_user_profile = mock.MagicMock(
+        spec=profiles.models.EndUserProfile(),
+        user=mocked_user
+    )
+    mocked_user.enduserprofile = mocked_end_user_profile
+    mocked_user.profile = mocked_end_user_profile
+    mocked_user.groups.return_value = [
+        mocked_group,
+    ]
+    mocked_user.keycloak.return_value = mock.MagicMock(
+        spec="bossoidc.models.Keycloak")
+    mocked_user.keycloak.UID = "fake_uuid"
+    mocked_user.email = "fake.mail@mail.com"
+    mocked_user.usename = "fake"
+    return mocked_user
+
+
+@pytest.fixture
+def mocked_tag(mocked_bike):
+    mocked_tag_class = mock.MagicMock(spec="vehicles.models.PhysicalTag")
+    mocked_tag = mocked_tag_class()
+    mocked_tag.bike = mocked_bike
+    mocked_tag.epc = "mocked-epc-123"
+    return mocked_tag

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -46,12 +46,3 @@ def mocked_end_user(mocked_user, settings):
     mocked_user.email = "fake.mail@mail.com"
     mocked_user.usename = "fake"
     return mocked_user
-
-
-@pytest.fixture
-def mocked_tag(mocked_bike):
-    mocked_tag_class = mock.MagicMock(spec="vehicles.models.PhysicalTag")
-    mocked_tag = mocked_tag_class()
-    mocked_tag.bike = mocked_bike
-    mocked_tag.epc = "mocked-epc-123"
-    return mocked_tag

--- a/tests/unittests/test_api_my_serializers.py
+++ b/tests/unittests/test_api_my_serializers.py
@@ -1,0 +1,45 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+from unittest import mock
+
+import pytest
+
+from api import serializers
+import vehicles.models
+
+pytestmark = pytest.mark.unit
+
+
+def test_myuserserializer_returns_my_url(api_request_factory, mocked_end_user):
+    serializer = serializers.MyUserSerializer(
+        instance=mocked_end_user,
+        context={
+            "request": None
+        }
+    )
+    assert serializer.data["url"] == "/api/my-user"
+
+
+def test_mybikesserializer_returns_my_urls(mocked_bike):
+    serializer = serializers.MyBikeDetailSerializer(
+        instance=mocked_bike,
+        context={"request": None}
+    )
+    print("serializer.data: {}".format(serializer.data))
+    assert serializer.data["owner"] == "/api/my-user"
+
+
+def test_myphysicaltagserializer_returns_my_urls(mocked_tag):
+    serializer = serializers.MyPhysicalTagSerializer(
+        instance=mocked_tag, context={"request": None}
+    )
+    assert serializer.data["url"].startswith("/api/my-tags")
+    assert serializer.data["bike_url"].startswith("/api/my-bikes")

--- a/tests/unittests/test_api_my_serializers.py
+++ b/tests/unittests/test_api_my_serializers.py
@@ -8,17 +8,14 @@
 #
 #########################################################################
 
-from unittest import mock
-
 import pytest
 
 from api import serializers
-import vehicles.models
 
 pytestmark = pytest.mark.unit
 
 
-def test_myuserserializer_returns_my_url(api_request_factory, mocked_end_user):
+def test_myuserserializer_returns_my_url(mocked_end_user):
     serializer = serializers.MyUserSerializer(
         instance=mocked_end_user,
         context={
@@ -26,15 +23,6 @@ def test_myuserserializer_returns_my_url(api_request_factory, mocked_end_user):
         }
     )
     assert serializer.data["url"] == "/api/my-user"
-
-
-def test_mybikesserializer_returns_my_urls(mocked_bike):
-    serializer = serializers.MyBikeDetailSerializer(
-        instance=mocked_bike,
-        context={"request": None}
-    )
-    print("serializer.data: {}".format(serializer.data))
-    assert serializer.data["owner"] == "/api/my-user"
 
 
 def test_myphysicaltagserializer_returns_my_urls(mocked_tag):

--- a/tests/unittests/test_api_my_serializers.py
+++ b/tests/unittests/test_api_my_serializers.py
@@ -23,11 +23,3 @@ def test_myuserserializer_returns_my_url(mocked_end_user):
         }
     )
     assert serializer.data["url"] == "/api/my-user"
-
-
-def test_myphysicaltagserializer_returns_my_urls(mocked_tag):
-    serializer = serializers.MyPhysicalTagSerializer(
-        instance=mocked_tag, context={"request": None}
-    )
-    assert serializer.data["url"].startswith("/api/my-tags")
-    assert serializer.data["bike_url"].startswith("/api/my-bikes")

--- a/tests/unittests/test_api_serializers.py
+++ b/tests/unittests/test_api_serializers.py
@@ -62,7 +62,6 @@ def test_smbuserhyperlinkedrelatedfield_returns_uuid(api_request_factory,
 
 
 def test_smbuserserializer_returns_uuid(api_request_factory, mocked_end_user):
-# def test_smbuserserializer_returns_uuid(api_request_factory, mocked_user):
     """verify that SmbUserSerializer returns the correct id data
 
     SmbUserSerializer should show ``id`` as being the keycloak UUID. Django

--- a/tests/unittests/test_api_serializers.py
+++ b/tests/unittests/test_api_serializers.py
@@ -61,7 +61,8 @@ def test_smbuserhyperlinkedrelatedfield_returns_uuid(api_request_factory,
     assert result.endswith("{}/".format(fake_uuid))
 
 
-def test_smbuserserializer_returns_uuid(api_request_factory, mocked_user):
+def test_smbuserserializer_returns_uuid(api_request_factory, mocked_end_user):
+# def test_smbuserserializer_returns_uuid(api_request_factory, mocked_user):
     """verify that SmbUserSerializer returns the correct id data
 
     SmbUserSerializer should show ``id`` as being the keycloak UUID. Django
@@ -72,12 +73,9 @@ def test_smbuserserializer_returns_uuid(api_request_factory, mocked_user):
     fake_uuid = "fake uuid"
     fake_request = api_request_factory.get(
         reverse("api:users-detail", kwargs={"uuid": fake_uuid}))
-    mocked_user.keycloak.return_value = mock.MagicMock(spec=Keycloak)
-    mocked_user.keycloak.UID = fake_uuid
-    mocked_user.profile = None
     serializer = serializers.SmbUserSerializer(
-        instance=mocked_user,
+        instance=mocked_end_user,
         context={"request": fake_request}
     )
     serializer_data = serializer.data
-    assert serializer_data["uuid"] == fake_uuid
+    assert serializer_data["uuid"] == mocked_end_user.keycloak.UID


### PR DESCRIPTION
This PR fixes incorrect URLs in the API endpoints that relate to resources owned by the current user (`/api/my-*` endpoints)

In addition, the following endpoints **have been removed** from the API:

- `/api/picture-galleries`
- `/api/pictures`

These endpoints have been removed since the underlying resources do not seem relevant enough to warrant dedicated API pages. A bike's pictures can be accessed directly on the `/api/bikes` endpoint and (at least for now) there are no other meaningful interactions to perform with bike pictures or galleries.

### Other changes
Also included is a fix in the portal template for the privileged user registration. Since the style revamp done a few weeks back, the portal footer was covering the submit button on the privileged user creation page.



fixes #110