### PR TITLE
add custom pagination class for user dump endpoint

### DIFF
--- a/smbportal/api/pagination.py
+++ b/smbportal/api/pagination.py
@@ -1,0 +1,17 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+"""Custom pagination classes for the portal"""
+
+from rest_framework.pagination import PageNumberPagination
+
+
+class SmbUserDumpPageNumberPagination(PageNumberPagination):
+    page_size = 500

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -26,6 +26,7 @@ import profiles.models
 import tracks.models
 import vehicles.models
 import vehiclemonitor.models
+from . import pagination
 from . import serializers
 from . import filters
 
@@ -172,6 +173,7 @@ class SmbUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         "username",
     )
     lookup_field = "uuid"
+    pagination_class = pagination.SmbUserDumpPageNumberPagination
 
     def get_object(self):
         obj = self.get_queryset().get(keycloak__UID=self.kwargs["uuid"])


### PR DESCRIPTION
This PR introduces a new pagination class that sets `page_size = 500`. This pagination class is applied to the view that serves the `/api/users/dump` endpoint.