### PR TITLE
change segment geometry representation to geojson

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -771,7 +771,7 @@ class SegmentSerializer(serializers.ModelSerializer):
     )
 
     def get_geom(self, obj):
-        return obj.geom.wkt
+        return obj.geom.geojson
 
     def get_emissions(self, obj):
         serializer = EmissionSerializer(


### PR DESCRIPTION
This PR fixes #142 

Segment geometries are now represented as GeoJSON objects instead of WKT