### PR TITLE
add badges fixes

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -24,3 +24,6 @@ git+https://github.com/jhuapl-boss/drf-oidc-auth.git@v0.8.0
 
 # includes a fix for jhuapl-boss/boss-oidc #28
 git+https://github.com/geosolutions-it/boss-oidc.git@4fad0f8579f4c091b8a80426407cad7d98969e28
+
+# smb-backend
+git+https://github.com/geosolutions-it/smb-backend.git

--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -173,6 +173,10 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
 
 class MyUserSerializer(SmbUserSerializer):
     url = serializers.SerializerMethodField()
+    total_health_benefits = serializers.SerializerMethodField()
+    total_emissions = serializers.SerializerMethodField()
+    total_distance_km = serializers.SerializerMethodField()
+    total_travels = serializers.SerializerMethodField()
 
     def get_url(self, obj):
         return reverse("api:my-user", request=self.context.get("request"))
@@ -213,6 +217,23 @@ class MyUserSerializer(SmbUserSerializer):
             result = serializer.data
         return result
 
+    def get_total_health_benefits(self, obj):
+        return tracks.utils.get_aggregated_data(
+            "health",
+            segment_filters={"track__owner": obj}
+        )
+
+    def get_total_emissions(self, obj):
+        return tracks.utils.get_aggregated_data(
+            "emissions",
+            segment_filters={"track__owner": obj}
+        )
+
+    def get_total_distance_km(self, obj):
+        return tracks.utils.get_total_distance_by_vehicle_type(obj)
+
+    def get_total_travels(self, obj):
+        return tracks.utils.get_total_travels_by_vehicle_type(obj)
 
     class Meta:
         model = profiles.models.SmbUser
@@ -232,6 +253,10 @@ class MyUserSerializer(SmbUserSerializer):
             "avatar",
             "acquired_badges",
             "next_badges",
+            "total_health_benefits",
+            "total_emissions",
+            "total_distance_km",
+            "total_travels",
         )
 
 

--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -13,6 +13,8 @@
 import logging
 
 from avatar.templatetags.avatar_tags import avatar_url
+from django.db.models import OuterRef
+from django.db.models import Subquery
 from rest_framework.reverse import reverse
 import photologue.models
 from rest_framework import serializers
@@ -23,7 +25,7 @@ import tracks.models
 import tracks.utils
 import vehicles.models
 import vehiclemonitor.models
-import django_gamification.models
+import django_gamification.models as gm
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +83,7 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
     profile_type = serializers.SerializerMethodField()
     password = serializers.CharField(write_only=True)
     acquired_badges = serializers.SerializerMethodField()
+    next_badges = serializers.SerializerMethodField()
     avatar = serializers.SerializerMethodField()
 
     def get_uuid(self, obj):
@@ -101,6 +104,29 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
             )
             result = serializer.data
         return result
+
+    def get_next_badges(self, obj):
+        if obj.gamification_interface is None:
+            result = []
+        else:
+            unacquired = gm.Badge.objects.filter(
+                acquired=False,
+                interface__smbuser=obj,
+                category=OuterRef("pk")
+            )
+            next_badges_ids = gm.Category.objects.annotate(
+                next_badge=Subquery(unacquired.values("pk")[:1])
+            ).values_list("next_badge", flat=True)
+            qs = gm.Badge.objects.filter(
+                pk__in=next_badges_ids).order_by("name")
+            serializer = BriefBadgeSerializer(
+                instance=qs,
+                context=self.context,
+                many=True
+            )
+            result = serializer.data
+        return result
+
 
     def get_profile(self, obj):
         if obj.profile is not None:
@@ -141,21 +167,22 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
             "profile_type",
             "avatar",
             "acquired_badges",
+            "next_badges",
         )
 
 
 class MyUserSerializer(SmbUserSerializer):
     url = serializers.SerializerMethodField()
-    badges = serializers.SerializerMethodField()
 
     def get_url(self, obj):
         return reverse("api:my-user", request=self.context.get("request"))
 
-    def get_badges(self, obj):
+    def get_acquired_badges(self, obj):
         if obj.gamification_interface is None:
             result = []
         else:
-            badges = obj.gamification_interface.badge_set.filter()
+            badges = obj.gamification_interface.badge_set.filter(
+                acquired=True).order_by("name")
             serializer = MyBriefBadgeSerializer(
                 instance=badges,
                 context=self.context,
@@ -163,6 +190,29 @@ class MyUserSerializer(SmbUserSerializer):
             )
             result = serializer.data
         return result
+
+    def get_next_badges(self, obj):
+        if obj.gamification_interface is None:
+            result = []
+        else:
+            unacquired = gm.Badge.objects.filter(
+                acquired=False,
+                interface__smbuser=obj,
+                category=OuterRef("pk")
+            )
+            next_badges_ids = gm.Category.objects.annotate(
+                next_badge=Subquery(unacquired.values("pk")[:1])
+            ).values_list("next_badge", flat=True)
+            qs = gm.Badge.objects.filter(
+                pk__in=next_badges_ids).order_by("name")
+            serializer = MyBriefBadgeSerializer(
+                instance=qs,
+                context=self.context,
+                many=True
+            )
+            result = serializer.data
+        return result
+
 
     class Meta:
         model = profiles.models.SmbUser
@@ -180,7 +230,8 @@ class MyUserSerializer(SmbUserSerializer):
             "profile",
             "profile_type",
             "avatar",
-            "badges",
+            "acquired_badges",
+            "next_badges",
         )
 
 
@@ -873,6 +924,10 @@ class BadgeSerializer(serializers.ModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="api:badges-detail",
     )
+    next_badge = serializers.HyperlinkedRelatedField(
+        view_name="api:badges-detail",
+        queryset=gm.Badge.objects.all()
+    )
 
     def get_user(self, obj):
         user = obj.interface.smbuser_set.first()
@@ -883,7 +938,7 @@ class BadgeSerializer(serializers.ModelSerializer):
         )
 
     class Meta:
-        model = django_gamification.models.Badge
+        model = gm.Badge
         fields = (
             "id",
             "url",
@@ -891,13 +946,14 @@ class BadgeSerializer(serializers.ModelSerializer):
             "user",
             "acquired",
             "description",
-            "category"
+            "category",
+            "next_badge",
         )
 
 
 class BriefBadgeSerializer(BadgeSerializer):
     class Meta:
-        model = django_gamification.models.Badge
+        model = gm.Badge
         fields = (
             "name",
             "url",
@@ -908,22 +964,27 @@ class MyBadgeSerializer(BadgeSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="api:my-badges-detail",
     )
+    next_badge = serializers.HyperlinkedRelatedField(
+        view_name="api:my-badges-detail",
+        queryset=gm.Badge.objects.all()
+    )
 
     class Meta:
-        model = django_gamification.models.Badge
+        model = gm.Badge
         fields = (
             "id",
             "url",
             "name",
             "acquired",
             "description",
-            "category"
+            "category",
+            "next_badge",
         )
 
 
 class MyBriefBadgeSerializer(MyBadgeSerializer):
     class Meta:
-        model = django_gamification.models.Badge
+        model = gm.Badge
         fields = (
             "name",
             "url",

--- a/smbportal/badges/constants.py
+++ b/smbportal/badges/constants.py
@@ -8,56 +8,59 @@
 #
 #########################################################################
 
-from django.utils.translation import ugettext_lazy as _
+NEW_USER_BADGE = "01_new_user"
 
-# FIXME: Translation of these might be problematic
 # NOTE: Badge points are used for unlockables, which we are not using here
-CATEGORIES = {
-    "user_registration": {
-        "name": _("user_registration"),
-        "description": _(""),
+CATEGORIES = [
+    {
+        "name": "user_registration",
+        "description": "",
         "badge_definitions": [
             {
-                "name": _("new_user"),
-                "description": _(
+                "name": NEW_USER_BADGE,
+                "description": (
                     "As soon as you sign up and install the APP you earn "
                     "this badge."
-                ),
+                )
+                ,
                 "progression_target": 0,  # this badge is awarded immediately
             },
         ]
     },
-    "data_collection": {
-        "name": _("data_collection"),
-        "description": _(""),
+    {
+        "name": "data_collection_frequency",
+        "description": "",
         "badge_definitions": [
             {
-                "name": _("data_collector_level0"),
-                "description": _(
+                "name": "02_data_collector_level0",
+                "description": (
                     "When you start entering the tracking data of your "
                     "transport modes, you get this badge."
                 ),
                 "progression_target": 1,
+                "next": "03_data_collector_level1",
             },
             {
-                "name": _("data_collector_level1"),
-                "description": _(
+                "name": "03_data_collector_level1",
+                "description": (
                     "When you have recorded activity in a week for each day, "
                     "you will get this badge."
                 ),
                 "progression_target": 7,
+                "next": "04_data_collector_level2",
             },
             {
-                "name": _("data_collector_level2"),
-                "description": _(
+                "name": "04_data_collector_level2",
+                "description": (
                     "When you have recorded activity in two weeks for each "
                     "day, you will get this badge."
                 ),
                 "progression_target": 14,
+                "next": "05_data_collector_level3",
             },
             {
-                "name": _("data_collector_level3"),
-                "description": _(
+                "name": "05_data_collector_level3",
+                "description": (
                     "When you have recorded activity in a month for each day, "
                     "you will get this badge."
                 ),
@@ -66,55 +69,65 @@ CATEGORIES = {
 
         ]
     },
-    "bike_usage": {
-        "name": _("bike_usage"),
-        "description": _(""),
+    {
+        "name": "bike_usage_frequency",
+        "description": "",
         "badge_definitions": [
             {
-                "name": _("biker_level1"),
-                "description": _(
+                "name": "06_biker_level1",
+                "description": (
                     "Start using your bike in the city! Use the bike three "
                     "times in a week and you will get this badge."
                 ),
                 "progression_target": 3,
+                "next": "07_biker_level2",
             },
             {
-                "name": _("biker_level2"),
-                "description": _(
+                "name": "07_biker_level2",
+                "description": (
                     "Reuse the bike three more times in the city in the next "
                     "week and you will get this badge."
                 ),
                 "progression_target": 6,
+                "next": "08_biker_level3",
             },
             {
-                "name": _("biker_level3"),
-                "description": _(
+                "name": "08_biker_level3",
+                "description": (
                     "Reuse the bike in the city another six times in the "
                     "next two weeks and you will get this badge!!"
                 ),
                 "progression_target": 12,
             },
+        ]
+    },
+    {
+        "name": "bike_travel",
+        "description": "",
+        "badge_definitions": [
             {
-                "name": _("bike_surfer_level1"),
-                "description": _(
+                "name": "12_bike_surfer_level1",
+                "description": (
                     "Use the bike for at least 10 km in urban areas and you "
                     "will get this badge! You have made a great contribution "
                     "to sustainable mobility in your city!"
                 ),
                 "progression_target": 10,
+                "next": "13_bike_surfer_level2",
             },
             {
-                "name": _("bike_surfer_level2"),
-                "description": _(
+                "name": "13_bike_surfer_level2",
+                "description": (
                     "Use the bike for at least 50 km in urban areas and you "
                     "will get this badge! You have made a great contribution "
                     "to sustainable mobility in your city!"
                 ),
                 "progression_target": 50,
+                "next": "14_bike_surfer_level3",
             },
             {
-                "name": _("bike_surfer_level3"),
-                "description": _(
+                "name": "14_bike_surfer_level3",
+                "description": (
                     "Use the bike for at least 100 km in urban areas and "
                     "you will get this badge! You have made a great "
                     "contribution to sustainable mobility in your city!"
@@ -123,58 +136,68 @@ CATEGORIES = {
             },
         ]
     },
-    "public_transport_usage": {
-        "name": _("public_transport_usage"),
-        "description": _(""),
+    {
+        "name": "public_transport_usage_frequency",
+        "description": "",
         "badge_definitions": [
             {
-                "name": _("public_mobility_level1"),
-                "description": _(
+                "name": "09_public_mobility_level1",
+                "description": (
                     "Block your car and use urban public transport (tram, "
                     "bus, metro)! On first use of public transport you will "
                     "get this badge."
                 ),
                 "progression_target": 1,
+                "next": "10_public_mobility_level2",
             },
             {
-                "name": _("public_mobility_level2"),
-                "description": _(
+                "name": "10_public_mobility_level2",
+                "description": (
                     "Block your car and use urban public transport (tram, "
                     "bus, metro)! On the fifth use of public transport you "
                     "will get this badge."
                 ),
                 "progression_target": 5,
+                "next": "11_public_mobility_level3",
             },
             {
-                "name": _("public_mobility_level3"),
-                "description": _(
+                "name": "11_public_mobility_level3",
+                "description": (
                     "Block your car and use urban public transport (tram, "
                     "bus, metro)! On the tenth use of public transport you "
                     "will get this badge."
                 ),
                 "progression_target": 10,
-            },
+            }
+        ]
+    },
+    {
+        "name": "bus_travel",
+        "description": "",
+        "badge_definitions": [
             {
-                "name": _("tpl_surfer_level1"),
-                "description": _(
+                "name": "15_tpl_surfer_level1",
+                "description": (
                     "Use the bus for at least 25 km in urban areas and you "
                     "will get this badge! You have made a great contribution "
                     "to sustainable mobility in your city!"
                 ),
                 "progression_target": 25,
+                "next": "16_tpl_surfer_level2",
             },
             {
-                "name": _("tpl_surfer_level2"),
-                "description": _(
+                "name": "16_tpl_surfer_level2",
+                "description": (
                     "Use the bus for at least 100 km in urban areas and you "
                     "will get this badge! You have made a great contribution "
                     "to sustainable mobility in your city!"
                 ),
                 "progression_target": 100,
+                "next": "17_tpl_surfer_level3",
             },
             {
-                "name": _("tpl_surfer_level3"),
-                "description": _(
+                "name": "17_tpl_surfer_level3",
+                "description": (
                     "Use the bus for at least 200 km in urban areas and you "
                     "will get this badge! You have made a great contribution "
                     "to sustainable mobility in your city!"
@@ -183,56 +206,66 @@ CATEGORIES = {
             },
         ]
     },
-    "sustainability": {
-        "name": _("sustainability"),
-        "description": _(""),
+    {
+        "name": "sustainable_travel",
+        "description": "",
         "badge_definitions": [
             {
-                "name": _("multi_surfer_level1"),
-                "description": _(
+                "name": "18_multi_surfer_level1",
+                "description": (
                     "Use sustainable means for at least 100 km in urban "
                     "areas and you will get this badge! You have made a "
                     "great contribution to sustainable mobility in your city!"
                 ),
                 "progression_target": 100,
+                "next": "19_multi_surfer_level2",
             },
             {
-                "name": _("multi_surfer_level2"),
-                "description": _(
+                "name": "19_multi_surfer_level2",
+                "description": (
                     "Use sustainable means for at least 250 km in urban areas "
                     "and you will get this badge! You have made a great "
                     "contribution to sustainable mobility in your city!"
                 ),
                 "progression_target": 250,
+                "next": "20_multi_surfer_level3",
             },
             {
-                "name": _("multi_surfer_level3"),
-                "description": _(
+                "name": "20_multi_surfer_level3",
+                "description": (
                     "Use sustainable means for at least 500 km in urban areas "
                     "and you will get this badge! You have made a great "
                     "contribution to sustainable mobility in your city!"
                 ),
                 "progression_target": 500,
-            },
+            }
+        ]
+    },
+    {
+        "name": "avoid_co2",
+        "description": "",
+        "badge_definitions": [
             {
-                "name": _("ecologist_level1"),
-                "description": _(
+                "name": "21_ecologist_level1",
+                "description": (
                     "Avoid emissions for 25 kg of CO2 in urban areas and you "
                     "will get this badge!"
                 ),
                 "progression_target": 25,
+                "next": "22_ecologist_level2",
             },
             {
-                "name": _("ecologist_level2"),
-                "description": _(
+                "name": "22_ecologist_level2",
+                "description": (
                     "Avoid emissions for 50 kg of CO2 in urban areas and you "
                     "will get this badge!"
                 ),
                 "progression_target": 50,
+                "next": "23_ecologist_level3",
             },
             {
-                "name": _("ecologist_level3"),
-                "description": _(
+                "name": "23_ecologist_level3",
+                "description": (
                     "Avoid emissions for 100 kg of CO2 in urban areas and "
                     "you will get this badge!"
                 ),
@@ -241,30 +274,32 @@ CATEGORIES = {
 
         ]
     },
-    "health_benefits": {
-        "name": _("health_benefits"),
-        "description": _(""),
+    {
+        "name": "health_benefit",
+        "description": "",
         "badge_definitions": [
             {
-                "name": _("healthy_level1"),
-                "description": _(
+                "name": "24_healthy_level1",
+                "description": (
                     'Consume a total of 750 calories thanks to your movements '
                     '"active" in urban areas and you will get this badge!'
                 ),
                 "progression_target": 750,
+                "next": "25_healthy_level2",
             },
             {
-                "name": _("healthy_level2"),
-                "description": _(
+                "name": "25_healthy_level2",
+                "description": (
                     'Consume a total of 2250 calories thanks to your '
                     'movements "active" in urban areas and you will get this '
                     'badge!'
                 ),
                 "progression_target": 2250,
+                "next": "26_healthy_level3",
             },
             {
-                "name": _("healthy_level3"),
-                "description": _(
+                "name": "26_healthy_level3",
+                "description": (
                     'Consume a total of 4500 calories thanks to your '
                     'movements "active" in urban areas and you will get this '
                     'badge!'
@@ -273,29 +308,31 @@ CATEGORIES = {
             },
         ]
     },
-    "cost_savings": {
-        "name": _("cost_savings"),
-        "description": _(""),
+    {
+        "name": "cost_savings",
+        "description": "",
         "badge_definitions": [
             {
-                "name": _("money_saver_level1"),
-                "description": _(
+                "name": "27_money_saver_level1",
+                "description": (
                     "Save a total of 6 € thanks to your sustainable travel "
                     "in urban areas and you will get this badge!"
                 ),
                 "progression_target": 6,
+                "next": "28_money_saver_level2",
             },
             {
-                "name": _("money_saver_level2"),
-                "description": _(
+                "name": "28_money_saver_level2",
+                "description": (
                     "Save a total of 12 € thanks to your sustainable travel "
                     "in urban areas and you will get this badge!"
                 ),
                 "progression_target": 12,
+                "next": "29_money_saver_level3",
             },
             {
-                "name": _("money_saver_level3"),
-                "description": _(
+                "name": "29_money_saver_level3",
+                "description": (
                     "Save a total of 24 € thanks to your sustainable travel "
                     "in urban areas and you will get this badge!"
                 ),
@@ -303,5 +340,5 @@ CATEGORIES = {
             },
         ]
     },
-}
+]
 

--- a/smbportal/badges/management/commands/createbadgedefinitions.py
+++ b/smbportal/badges/management/commands/createbadgedefinitions.py
@@ -11,12 +11,15 @@
 import re
 
 from django.core.management.base import BaseCommand
+from django.db import connections
 
 import django_gamification.models as gm
+from smbbackend.updatebadges import update_badges
 
 from badges import  utils
 from badges.constants import CATEGORIES
 import profiles.models as pm
+import tracks.models as tm
 
 
 class Command(BaseCommand):
@@ -25,63 +28,77 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write(
             "Deleting any previous gamification features...")
-        self.drop_previous_gamification_interfaces()
-        self.drop_previous_badge_definitions()
+        drop_previous_gamification_interfaces()
+        drop_previous_badge_definitions()
         self.stdout.write("Adding gamification interface to endusers...")
-        self.add_user_gamification_interfaces()
+        add_user_gamification_interfaces()
         self.stdout.write("Generating badge definitions and badges...")
-        self.generate_categories(CATEGORIES)
-        self.generate_badge_definitions(CATEGORIES)
+        generate_categories(CATEGORIES)
+        generate_badge_definitions(CATEGORIES)
         self.stdout.write("Awarding `new user` badge for existing users...")
-        self.award_new_user_badges()
+        award_new_user_badges()
+        self.stdout.write("Updating current badges for all existing users...")
+        update_all_badges()
         self.stdout.write("Done!")
 
-    def drop_previous_gamification_interfaces(self):
-        gm.GamificationInterface.objects.all().delete()
 
-    def drop_previous_badge_definitions(self):
-        gm.BadgeDefinition.objects.all().delete()
+def drop_previous_gamification_interfaces():
+    gm.GamificationInterface.objects.all().delete()
 
-    def add_user_gamification_interfaces(self):
-        for enduser_profile in pm.EndUserProfile.objects.all():
-            user = enduser_profile.user
-            utils.add_gamification_interface(user)
 
-    def generate_badge_definitions(self, category_definitions):
-        defs = []
-        for category_info in category_definitions:
-            for badge_info in category_info["badge_definitions"]:
-                info = badge_info.copy()
-                info["category"] = gm.Category.objects.get(
-                    name=category_info["name"])
-                defs.append(info)
-        ordered_defs = sort_badge_definitions(defs)
-        for badge_definition in reversed(ordered_defs):
-            next_name = badge_definition.get("next")
-            if next_name is not None:
-                next_badge = gm.BadgeDefinition.objects.get(name=next_name)
-            else:
-                next_badge = None
-            gm.BadgeDefinition.objects.create(
-                name=badge_definition["name"],
-                description=badge_definition["description"],
-                points=badge_definition.get("points"),
-                progression_target=badge_definition.get("progression_target"),
-                category=badge_definition["category"],
-                next_badge=next_badge
-            )
+def drop_previous_badge_definitions():
+    gm.BadgeDefinition.objects.all().delete()
 
-    def generate_categories(self, category_definitions):
-        for category_info in category_definitions:
-            gm.Category.objects.get_or_create(
-                name=category_info["name"],
-                description=category_info["description"]
-            )
 
-    def award_new_user_badges(self):
-        for enduser_profile in pm.EndUserProfile.objects.all():
-            user = enduser_profile.user
-            utils.award_new_user_badge(user)
+def add_user_gamification_interfaces():
+    for enduser_profile in pm.EndUserProfile.objects.all():
+        user = enduser_profile.user
+        utils.add_gamification_interface(user)
+
+
+def generate_badge_definitions(category_definitions):
+    defs = []
+    for category_info in category_definitions:
+        for badge_info in category_info["badge_definitions"]:
+            info = badge_info.copy()
+            info["category"] = gm.Category.objects.get(
+                name=category_info["name"])
+            defs.append(info)
+    ordered_defs = sort_badge_definitions(defs)
+    for badge_definition in reversed(ordered_defs):
+        next_name = badge_definition.get("next")
+        if next_name is not None:
+            next_badge = gm.BadgeDefinition.objects.get(name=next_name)
+        else:
+            next_badge = None
+        gm.BadgeDefinition.objects.create(
+            name=badge_definition["name"],
+            description=badge_definition["description"],
+            points=badge_definition.get("points"),
+            progression_target=badge_definition.get("progression_target"),
+            category=badge_definition["category"],
+            next_badge=next_badge
+        )
+
+
+def generate_categories(category_definitions):
+    for category_info in category_definitions:
+        gm.Category.objects.get_or_create(
+            name=category_info["name"],
+            description=category_info["description"]
+        )
+
+
+def award_new_user_badges():
+    for enduser_profile in pm.EndUserProfile.objects.all():
+        user = enduser_profile.user
+        utils.award_new_user_badge(user)
+
+
+def update_all_badges():
+    for track in tm.Track.objects.all():
+        db_connection = connections["default"].connection
+        update_badges(track.pk, db_connection)
 
 
 def sort_badge_definitions(items, regexp="(\d+)"):

--- a/smbportal/badges/management/commands/createbadgedefinitions.py
+++ b/smbportal/badges/management/commands/createbadgedefinitions.py
@@ -8,6 +8,8 @@
 #
 #########################################################################
 
+import re
+
 from django.core.management.base import BaseCommand
 
 import django_gamification.models as gm
@@ -15,7 +17,6 @@ import django_gamification.models as gm
 from badges import  utils
 from badges.constants import CATEGORIES
 import profiles.models as pm
-
 
 
 class Command(BaseCommand):
@@ -29,8 +30,8 @@ class Command(BaseCommand):
         self.stdout.write("Adding gamification interface to endusers...")
         self.add_user_gamification_interfaces()
         self.stdout.write("Generating badge definitions and badges...")
-        for cat_name, cat_config in CATEGORIES.items():
-            self.generate_category(**cat_config)
+        self.generate_categories(CATEGORIES)
+        self.generate_badge_definitions(CATEGORIES)
         self.stdout.write("Awarding `new user` badge for existing users...")
         self.award_new_user_badges()
         self.stdout.write("Done!")
@@ -46,22 +47,47 @@ class Command(BaseCommand):
             user = enduser_profile.user
             utils.add_gamification_interface(user)
 
-    def generate_category(self, name="", description="",
-                          badge_definitions=None, **kwargs):
-        category, created = gm.Category.objects.get_or_create(
-            name=name,
-            description=description
-        )
-        for definition in badge_definitions or []:
-            badge_def = gm.BadgeDefinition.objects.create(
-                name=definition["name"],
-                description=definition["description"],
-                points=definition.get("points"),
-                progression_target=definition.get("progression_target"),
-                category=category,
+    def generate_badge_definitions(self, category_definitions):
+        defs = []
+        for category_info in category_definitions:
+            for badge_info in category_info["badge_definitions"]:
+                info = badge_info.copy()
+                info["category"] = gm.Category.objects.get(
+                    name=category_info["name"])
+                defs.append(info)
+        ordered_defs = sort_badge_definitions(defs)
+        for badge_definition in reversed(ordered_defs):
+            next_name = badge_definition.get("next")
+            if next_name is not None:
+                next_badge = gm.BadgeDefinition.objects.get(name=next_name)
+            else:
+                next_badge = None
+            gm.BadgeDefinition.objects.create(
+                name=badge_definition["name"],
+                description=badge_definition["description"],
+                points=badge_definition.get("points"),
+                progression_target=badge_definition.get("progression_target"),
+                category=badge_definition["category"],
+                next_badge=next_badge
+            )
+
+    def generate_categories(self, category_definitions):
+        for category_info in category_definitions:
+            gm.Category.objects.get_or_create(
+                name=category_info["name"],
+                description=category_info["description"]
             )
 
     def award_new_user_badges(self):
         for enduser_profile in pm.EndUserProfile.objects.all():
             user = enduser_profile.user
             utils.award_new_user_badge(user)
+
+
+def sort_badge_definitions(items, regexp="(\d+)"):
+    return sorted(
+        items,
+        key=lambda item: [int(c) if c.isdigit() else c for
+                          c in re.split(regexp, item["name"])]
+    )
+

--- a/smbportal/badges/utils.py
+++ b/smbportal/badges/utils.py
@@ -12,7 +12,7 @@
 
 import django_gamification.models as gm
 
-from .constants import CATEGORIES
+from . import constants
 
 
 def add_gamification_interface(user):
@@ -24,9 +24,7 @@ def add_gamification_interface(user):
 
 def award_new_user_badge(user):
     interface = user.gamification_interface
-    new_user_badge = interface.badge_set.get(
-        name=CATEGORIES[
-            "user_registration"]["badge_definitions"][0]["name"])
+    new_user_badge = interface.badge_set.get(name=constants.NEW_USER_BADGE)
     if not new_user_badge.acquired:
         new_user_badge.award()
         new_user_badge.save()

--- a/smbportal/locale/it/LC_MESSAGES/django.po
+++ b/smbportal/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-17 16:13+0000\n"
+"POT-Creation-Date: 2018-09-24 16:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: base/settings/base.py:196
+#: base/settings/base.py:198
 msgid "English"
 msgstr "English"
 
-#: base/settings/base.py:197
+#: base/settings/base.py:199
 msgid "Italian"
 msgstr "Italian"
 
@@ -29,263 +29,267 @@ msgstr "Italian"
 msgid "Did not accept the portal's Terms of Service"
 msgstr "Non sono stati accettati i termini di servizio della piattaforma"
 
-#: profiles/models.py:29
+#: profiles/models.py:30
 msgid "nickname"
 msgstr "Nome utente"
 
-#: profiles/models.py:34
+#: profiles/models.py:35
 msgid "language preference"
 msgstr "Lingua preferita"
 
-#: profiles/models.py:116 profiles/models.py:208
+#: profiles/models.py:46
+msgid "gamification interface"
+msgstr ""
+
+#: profiles/models.py:124 profiles/models.py:216
 msgid "user"
 msgstr "Utente"
 
-#: profiles/models.py:119
+#: profiles/models.py:127
 msgid "date updated"
 msgstr "Data aggiornata"
 
-#: profiles/models.py:123
+#: profiles/models.py:131
 msgid "gender"
 msgstr "Sesso"
 
-#: profiles/models.py:127
+#: profiles/models.py:135
 msgid "female"
 msgstr "Femmina"
 
-#: profiles/models.py:128
+#: profiles/models.py:136
 msgid "male"
 msgstr "Maschio"
 
-#: profiles/models.py:133
+#: profiles/models.py:141
 msgid "age"
 msgstr "Età"
 
-#: profiles/models.py:137
+#: profiles/models.py:145
 msgid "< 19"
 msgstr ""
 
-#: profiles/models.py:138
+#: profiles/models.py:146
 msgid "19 - 30"
 msgstr ""
 
-#: profiles/models.py:139
+#: profiles/models.py:147
 msgid "30 - 65"
 msgstr ""
 
-#: profiles/models.py:140
+#: profiles/models.py:148
 msgid "65+"
 msgstr ""
 
-#: profiles/models.py:149
+#: profiles/models.py:157
 msgid "phone number"
 msgstr "Numero di telefono"
 
-#: profiles/models.py:155
+#: profiles/models.py:163
 msgid "bio"
 msgstr "Bio"
 
-#: profiles/models.py:156
+#: profiles/models.py:164
 msgid "Short user biography"
 msgstr "Breve biografia"
 
-#: profiles/models.py:160
+#: profiles/models.py:168
 msgid "occupation"
 msgstr "Occupazione"
 
-#: profiles/models.py:163
+#: profiles/models.py:171
 msgid "insurance agent"
 msgstr "agente assicurativo"
 
-#: profiles/models.py:164
+#: profiles/models.py:172
 msgid "trading agent"
 msgstr "agente di commercio"
 
-#: profiles/models.py:165
+#: profiles/models.py:173
 msgid "freelancer"
 msgstr "altra libera professione"
 
-#: profiles/models.py:166
+#: profiles/models.py:174
 msgid "architect"
 msgstr "architetto"
 
-#: profiles/models.py:167
+#: profiles/models.py:175
 msgid "craftsman"
 msgstr "artigiano"
 
-#: profiles/models.py:168
+#: profiles/models.py:176
 msgid "artist"
 msgstr "artista"
 
-#: profiles/models.py:169
+#: profiles/models.py:177
 msgid "lawyer"
 msgstr "avvocato"
 
-#: profiles/models.py:170
+#: profiles/models.py:178
 msgid "housewife"
 msgstr "casalinga"
 
-#: profiles/models.py:171
+#: profiles/models.py:179
 msgid "accountant"
 msgstr "commercialista"
 
-#: profiles/models.py:172
+#: profiles/models.py:180
 msgid "dealer"
 msgstr "commerciante"
 
-#: profiles/models.py:173
+#: profiles/models.py:181
 msgid "shop assistant"
 msgstr "commesso"
 
-#: profiles/models.py:174
+#: profiles/models.py:182
 msgid "consultant"
 msgstr "consulente"
 
-#: profiles/models.py:175
+#: profiles/models.py:183
 msgid "public agency employee"
 msgstr "dipendente pubblica amministrazione"
 
-#: profiles/models.py:176
+#: profiles/models.py:184
 msgid "private sector employee"
 msgstr "dipendente di azienda privata"
 
-#: profiles/models.py:177
+#: profiles/models.py:185
 msgid "manager"
 msgstr "dirigente"
 
-#: profiles/models.py:178
+#: profiles/models.py:186
 msgid "public agency manager"
 msgstr "dirigente/funzionario p.a./ufficiale"
 
-#: profiles/models.py:179
+#: profiles/models.py:187
 msgid "pharmacist"
 msgstr "farmacista"
 
-#: profiles/models.py:180
+#: profiles/models.py:188
 msgid "surveyor"
 msgstr "geometra"
 
-#: profiles/models.py:181
+#: profiles/models.py:189
 msgid "journalist"
 msgstr "giornalista"
 
-#: profiles/models.py:182
+#: profiles/models.py:190
 msgid "entrepreneur"
 msgstr "imprenditore"
 
-#: profiles/models.py:183
+#: profiles/models.py:191
 msgid "engineer"
 msgstr "ingegnere"
 
-#: profiles/models.py:184
+#: profiles/models.py:192
 msgid "teacher"
 msgstr "insegnante"
 
-#: profiles/models.py:185
+#: profiles/models.py:193
 msgid "doctor"
 msgstr "medico"
 
-#: profiles/models.py:186
+#: profiles/models.py:194
 msgid "unemployed"
 msgstr "non occupato"
 
-#: profiles/models.py:187
+#: profiles/models.py:195
 msgid "notary"
 msgstr "notaio"
 
-#: profiles/models.py:188
+#: profiles/models.py:196
 msgid "worker"
 msgstr "operaio"
 
-#: profiles/models.py:189
+#: profiles/models.py:197
 msgid "retired"
 msgstr "pensionato"
 
-#: profiles/models.py:190
+#: profiles/models.py:198
 msgid "politician"
 msgstr "politico"
 
-#: profiles/models.py:191
+#: profiles/models.py:199
 msgid "university professor"
 msgstr "professore universitario"
 
-#: profiles/models.py:192
+#: profiles/models.py:200
 msgid "trainee"
 msgstr "stagista/tirocinante"
 
-#: profiles/models.py:193
+#: profiles/models.py:201
 msgid "professional athlete"
 msgstr "sportivo professionista"
 
-#: profiles/models.py:194
+#: profiles/models.py:202
 msgid "high school student"
 msgstr "studente scuola superiore"
 
-#: profiles/models.py:195
+#: profiles/models.py:203
 msgid "college student"
 msgstr "studente universitario"
 
-#: profiles/models.py:233
+#: profiles/models.py:241
 msgid "end user"
 msgstr "Utente finale"
 
-#: profiles/models.py:236
+#: profiles/models.py:244
 msgid "date answered"
 msgstr "Data della risposta"
 
-#: profiles/models.py:240
+#: profiles/models.py:248
 msgid "public transport usage"
 msgstr "Utilizzo dei trasporti pubblici"
 
-#: profiles/models.py:245
+#: profiles/models.py:253
 msgid "Habitual (more than 10 travels per month)"
 msgstr "Abituale (oltre 10 viaggi al mese)"
 
-#: profiles/models.py:249
+#: profiles/models.py:257
 msgid "Occasional (once per month)"
 msgstr "Sporadico (un viaggio al mese)"
 
-#: profiles/models.py:253
+#: profiles/models.py:261
 msgid "Rare (less than 10 travels per year)"
 msgstr "Raro (meno di 10 viaggi l'anno)"
 
-#: profiles/models.py:257
+#: profiles/models.py:265
 msgid "Never"
 msgstr "Mai"
 
-#: profiles/models.py:263
+#: profiles/models.py:271
 msgid "uses bike sharing services"
 msgstr "utilizzo servizi di bike sharing"
 
-#: profiles/models.py:267
+#: profiles/models.py:275
 msgid "uses electrical car sharing services"
 msgstr "utilizzo servizi di car sharing elettrico"
 
-#: profiles/models.py:271
+#: profiles/models.py:279
 msgid "uses fuel car sharing services"
 msgstr "uso servizi di car sharing"
 
-#: profiles/models.py:275
+#: profiles/models.py:283
 msgid "bicycle usage"
 msgstr "Utilizzo della bicicletta"
 
-#: profiles/models.py:280
+#: profiles/models.py:288
 msgid "Habitual (at least once a week on average)"
 msgstr "Abituale (almeno una volta alla settimana)"
 
-#: profiles/models.py:284
+#: profiles/models.py:292
 msgid "Habitual (at least once a month)"
 msgstr "Sporadico (almeno una volta al mese)"
 
-#: profiles/models.py:288
+#: profiles/models.py:296
 msgid "Seasonal (mainly used in the Summer)"
 msgstr "Stagionale (principalmente in primavera/estate)"
 
-#: profiles/models.py:292
+#: profiles/models.py:300
 msgid "Rare (less than once a month)"
 msgstr "Raro (meno di una volta al mese)"
 
-#: profiles/models.py:296
+#: profiles/models.py:304
 msgid "Never use a bicycle to move around in the city"
 msgstr "Non utilizzo mai la bicicletta per muovermi in città"
 
@@ -301,15 +305,15 @@ msgstr "La richeista di registrazione è stata inviata agli amministratori"
 msgid "You have been logged out"
 msgstr "Disconnesso"
 
-#: profiles/views.py:219
+#: profiles/views.py:223
 msgid "User profile created. You can now add some bikes"
 msgstr "Profilo utente createo. Adesso puoi aggiungere le tue biciclette"
 
-#: profiles/views.py:289
+#: profiles/views.py:293
 msgid "User profile updated!"
 msgstr "Profilo utente aggiornato!"
 
-#: profiles/views.py:332
+#: profiles/views.py:337
 msgid "Please complete your user profile before continuing"
 msgstr "Completa il tuo profilo utente per poter continuare nella navigazione"
 


### PR DESCRIPTION
This PR has some changes to badges API in order to ease client interactions:

- badge info is not localizable in the server side anymore. This was done in order to keep consistency for the client app;
-  changed badge names to have an id for easing ordering. Since the underlying django_gamification app does not allow storing additional metadata for each badge, it is not straight forward to control the ordering of badges. As such the name of each badge has been altered in order to contain its implicit ordering. Naming of badges now follows the form: `<badge_ordering_id>_<badge_name>`. Example: `01_new_user`
-  added next_badges to user API endpoints - The `/api/my-user` endpoint now returns the following attributes for the user object:

   ```
   "acquired_badges": [
    {
      "name": "02_data_collector_level0",
      "url": "http://10.0.1.66:8000/api/my-badges/1774/",
      "acquired": true
    },
    {
      "name": "01_new_user",
      "url": "http://10.0.1.66:8000/api/my-badges/1779/",
      "acquired": true
    }
    ],
   "next_badges": [
    {
      "name": "24_healthy_level1",
      "url": "http://10.0.1.66:8000/api/my-badges/1664/",
      "acquired": false
    },
    {
      "name": "09_public_mobility_level1",
      "url": "http://10.0.1.66:8000/api/my-badges/1739/",
      "acquired": false
    },
    {
      "name": "27_money_saver_level1",
      "url": "http://10.0.1.66:8000/api/my-badges/1649/",
      "acquired": false
    },
    {
      "name": "03_data_collector_level1",
      "url": "http://10.0.1.66:8000/api/my-badges/1769/",
      "acquired": false
    },
    {
      "name": "06_biker_level1",
      "url": "http://10.0.1.66:8000/api/my-badges/1754/",
      "acquired": false
    },
    {
      "name": "18_multi_surfer_level1",
      "url": "http://10.0.1.66:8000/api/my-badges/1694/",
      "acquired": false
    }
   ]
   ```

## ~NOTE~

~Badge categories as indicated in `smbportal.badges.constants` need to be slightly tweaked in order to correctly match the expected results. That will be done in the next PR~ - This has been included in this PR