### PR TITLE
add order_by clause in badges viewsets

### DIFF
--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -345,7 +345,8 @@ class BadgeViewSet(viewsets.ReadOnlyModelViewSet):
     filter_fields = (
         "acquired",
     )
-    queryset = django_gamification.models.Badge.objects.all()
+    queryset = django_gamification.models.Badge.objects.all().order_by(
+        "-acquired", "name")
 
 
 class MyBadgeViewSet(viewsets.ReadOnlyModelViewSet):
@@ -362,4 +363,4 @@ class MyBadgeViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return django_gamification.models.Badge.objects.filter(
-            interface__smbuser=self.request.user)
+            interface__smbuser=self.request.user).order_by("-acquired", "name")


### PR DESCRIPTION
This PR adds custom ordering to badges when using the viewsets for `/api/badges` and `/api/my-badges`

Ordering is done first by the badge's `acquired` status and then by the badge's `name` attribute