### PR TITLE
my-user API endpoint now allows updating user fields

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -18,6 +18,7 @@ from django.db.models import Subquery
 from rest_framework.reverse import reverse
 import photologue.models
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 import profiles.models
@@ -81,7 +82,6 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
     uuid = serializers.SerializerMethodField()
     profile = serializers.SerializerMethodField()
     profile_type = serializers.SerializerMethodField()
-    password = serializers.CharField(write_only=True)
     acquired_badges = serializers.SerializerMethodField()
     next_badges = serializers.SerializerMethodField()
     avatar = serializers.SerializerMethodField()
@@ -129,15 +129,9 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
 
 
     def get_profile(self, obj):
-        if obj.profile is not None:
-            serializer_class = {
-                "enduserprofile": EndUserProfileSerializer,
-                "privilegeduserprofile": (
-                    PrivilegedUserProfileSerializer),
-            }.get(obj.profile.__class__.__name__.lower())
-            print("class: {}".format(obj.profile.__class__))
-            print("class_name: {}".format(obj.profile.__class__.__name__))
-            print("serializer class: {}".format(serializer_class))
+        profile_type = self.get_profile_type(obj)
+        if profile_type is not None:
+            serializer_class = self._get_profile_serializer_class(profile_type)
             serializer = serializer_class(
                 instance=obj.profile,
                 context=self.context
@@ -150,13 +144,18 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
     def get_profile_type(self, obj):
         return type(obj.profile).__name__.lower() if obj.profile else None
 
+    def _get_profile_serializer_class(self, profile_type):
+        return {
+            "privilegeduserprofile": (
+                PrivilegedUserProfileSerializer),
+        }.get(profile_type, EndUserProfileSerializer)
+
     class Meta:
         model = profiles.models.SmbUser
         fields = (
             "url",
             "uuid",
             "username",
-            "password",
             "email",
             "date_joined",
             "language_preference",
@@ -172,11 +171,69 @@ class SmbUserSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class MyUserSerializer(SmbUserSerializer):
+    username = serializers.CharField(required=False)
+    accepted_terms_of_service = serializers.BooleanField(write_only=True)
+    nickname = serializers.CharField(required=False)
+    language_preference = serializers.CharField(required=False)
     url = serializers.SerializerMethodField()
     total_health_benefits = serializers.SerializerMethodField()
     total_emissions = serializers.SerializerMethodField()
     total_distance_km = serializers.SerializerMethodField()
     total_travels = serializers.SerializerMethodField()
+
+    def update(self, instance, validated_data):
+        instance.username = validated_data.get("username", instance.username)
+        instance.nickname = validated_data.get("nickname", instance.nickname)
+        instance.accepted_terms_of_service = validated_data.get(
+            "accepted_terms_of_service", instance.accepted_terms_of_service)
+        instance.language_preference = validated_data.get(
+            "language_preference", instance.language_preference)
+        # The profile-related fields are fetched from `initial_data` instead
+        # `validated_data` intentionally. Since their representation
+        # is being created using `serializers.SerializerMethodField`, they
+        # are supposed to be readonly, and thus rest-framework does not use
+        # them for data updates (so they do not show up in `validated_data`).
+        # This is likely a hacky way to support different models under the
+        # same `profile` attribute name
+        initial_data = getattr(self, "initial_data", {})
+        profile_type = initial_data.get("profile_type")
+        profile_data = initial_data.get("profile")
+        if profile_data is not None:
+            self._update_profile(instance, profile_data, profile_type)
+        instance.save()
+        return instance
+
+    def _update_profile(self, instance, profile_data, profile_type):
+        """Update the nested `profile` resource"""
+        profile_type_matches = self.get_profile_type(instance) == profile_type
+        is_correct_profile_type = (
+            (profile_type_matches and profile_type is not None) or
+            (profile_type is None)
+        )
+        if not is_correct_profile_type:
+            raise ValidationError({"profile_type": "incorrect value"})
+        profile_serializer_context = self.context.copy()
+        profile_serializer_context.update({
+            "user": instance
+        })
+        profile_serializer_class = self._get_profile_serializer_class(
+            profile_type)
+        current_profile = instance.profile
+        if current_profile is None:
+            profile_serializer = profile_serializer_class(
+                data=profile_data,
+                context=profile_serializer_context
+            )
+        else:
+            profile_serializer = profile_serializer_class(
+                instance=current_profile,
+                data=profile_data,
+                context=profile_serializer_context,
+                partial=True
+            )
+        profile_serializer.is_valid(raise_exception=True)
+        user_profile = profile_serializer.save()
+        return user_profile
 
     def get_url(self, obj):
         return reverse("api:my-user", request=self.context.get("request"))
@@ -238,10 +295,10 @@ class MyUserSerializer(SmbUserSerializer):
     class Meta:
         model = profiles.models.SmbUser
         fields = (
+            "accepted_terms_of_service",
             "url",
             "uuid",
             "username",
-            "password",
             "email",
             "date_joined",
             "language_preference",
@@ -294,6 +351,7 @@ class UserDumpSerializer(SmbUserSerializer):
 
 
 class EndUserProfileSerializer(serializers.ModelSerializer):
+    date_updated = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = profiles.models.EndUserProfile
@@ -305,6 +363,23 @@ class EndUserProfileSerializer(serializers.ModelSerializer):
             "date_updated",
             "occupation",
         )
+
+    def create(self, validated_data):
+        return profiles.models.EndUserProfile.objects.create(
+            user=self.context["user"],
+            **validated_data
+        )
+
+    def update(self, instance, validated_data):
+        instance.gender = validated_data.get("gender", instance.gender)
+        instance.age = validated_data.get("age", instance.gender)
+        instance.phone_number = validated_data.get(
+            "phone_number", instance.gender)
+        instance.bio = validated_data.get("bio", instance.gender)
+        instance.occupation = validated_data.get(
+            "occupation", instance.occupation)
+        instance.save()
+        return instance
 
 
 class PrivilegedUserProfileSerializer(serializers.ModelSerializer):

--- a/smbportal/keycloakauth/utils.py
+++ b/smbportal/keycloakauth/utils.py
@@ -9,13 +9,19 @@
 #########################################################################
 
 import logging
+from typing import List
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from bossoidc.models import Keycloak
 from requests.exceptions import HTTPError
 
 from base.utils import get_group_name
+from profiles.models import SmbUser
+
+from . import oidchooks
+from .keycloakadmin import get_manager
 
 logger = logging.getLogger(__name__)
 
@@ -71,3 +77,69 @@ def create_django_user(username, email, keycloak_id, group_name,
             **kwargs
         )
     return user
+
+
+def update_user_groups(user: SmbUser, user_profile: str,
+                       current_keycloak_groups: List[str]):
+    """Update a user's groups based on the requested user profile
+
+    The workflow is:
+
+    - user asks Keycloak to become a member of the group(s) corresponding
+      to its profile
+    - Keycloak either accepts and creates the memberships or denies and
+      notifies an admin that user wants to be given membership of said groups
+    - if Keycloak created the relevant memberships, we update the user's
+      django groups
+
+    Note:
+
+    We do not use permissions here because we want Keycloak to be the
+    authority on the user group memberships. In order to do that we can only
+    update a django user's django group when we are certain that Keycloak
+    already has reflected that membership in its own user database
+
+    """
+
+    keycloak_groups = enforce_keycloak_group_memberships(
+        user.keycloak.UID,
+        user_profile,
+        current_keycloak_groups
+    )
+    oidchooks.create_django_memberships(user, keycloak_groups)
+
+
+def enforce_keycloak_group_memberships(user_id: str, user_profile: str,
+                                       current_groups: List[str]):
+    """Assign user memberships on the relevant KeyCloak groups, if allowed.
+
+    The registration of some user profiles, like `end_user`, is automatically
+    accepted, resulting in the relevant KeyCloak groups needing to be updated
+    with new members. Other profile types are not allowed to self register as
+    group members on KeyCloak.
+
+    """
+
+    memberships_to_enforce = settings.KEYCLOAK["group_mappings"][user_profile]
+    if set(current_groups) == set(memberships_to_enforce):
+        result = current_groups
+    else:
+        keycloak_manager = get_manager(
+            base_url=settings.KEYCLOAK["base_url"],
+            realm=settings.KEYCLOAK["realm"],
+            client_id=settings.KEYCLOAK["client_id"],
+            username=settings.KEYCLOAK["admin_username"],
+            password=settings.KEYCLOAK["admin_password"],
+        )
+        if user_profile == settings.END_USER_PROFILE:
+            missing_memberships = set(
+                memberships_to_enforce) - set(current_groups)
+            if any(missing_memberships):
+                for group_path in missing_memberships:
+                    keycloak_manager.add_user_to_group(user_id, group_path)
+            result = memberships_to_enforce
+        else:
+            keycloak_manager.set_user_access(user_id, enabled=False)
+            raise RuntimeError("profiles of type {!r} must be manually "
+                               "approved by an admin".format(user_profile))
+    return result

--- a/smbportal/profiles/rules.py
+++ b/smbportal/profiles/rules.py
@@ -44,6 +44,7 @@ is_end_user = rules.is_group_member("end_users")
 is_privileged_user = rules.is_group_member("privileged_users")
 
 for perm, predicate in {
+    "is_authenticated": rules.is_authenticated,
     "can_list_users": is_privileged_user,
     "can_delete_user": is_admin,
     "can_create_profile": ~has_profile,


### PR DESCRIPTION
This PR allows the `/api/my-user` endpoint to be used for updating a user's fields.

It is now possible to use the following workflow:

-  A prospecting user visits the keycloak realm registration page (either by visiting the URL directly or by being redirected to keycloak from the portal's `register` link)
-  The user completes the keycloak registration form - this means that the user is known to keycloak, but is not known to the portal yet
-  The user can now interact with the backend code by either:

   -  Visiting the portal. The user will need to complete its profile page before gaining access to most sections of the profile;
   - making a `PATCH` request to `/api/my-user` (most likely by using the goodgo mobile app, which does this on the user's behalf) with information to complete the user's profile

-  After the user's profile is complete with the minimum fields (`age`, `accepted_terms_of_service`, `occupation`), the user may use all of the platform's functionalities

Creating/updating the user's profile via the API may be done with a request like the following:

```
PATCH /api/my-user
{
  "accepted_terms_of_service": true,
  "profile": {
    "gender": "female",
    "occupation": "manager",
    "age": "30 - 65"
  }
}
```

#### Implementation details

Upon receiving a request to update a profile for a user that does not exist yet on django, the code proceeds to:
-  validate that the user exists on keycloak (by using the provided access token in order to query keycloak for the user's information)
-  create the new django user
-  create a user profile for the new user
-  depending on the type of profile being created, either communicate with keycloak in order to assign the correct group memberships (and then sync them with the django code) or notify an administrator that a new user wants access as a special user profile 

fixes #153 