### PR TITLE
add support for fcm_django and also API endpoints for managing user d…

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,9 +10,11 @@ django-filter==1.1.0
 django-ipware==2.1.0
 django-photologue==3.8.1
 drf-yasg==1.8.0
+fcm-django==0.2.19
 geoip2==2.9.0
 lxml==4.2.3
 psycopg2-binary==2.7.4
+pyfcm==1.4.5
 pygdal==2.2.3.3 # depends on libgdal-dev 2.3.3
 pytz==2018.4
 requests==2.18.4

--- a/smbportal/api/urls.py
+++ b/smbportal/api/urls.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.urls import path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
+from fcm_django.api.rest_framework import FCMDeviceAuthorizedViewSet
 from rest_framework import routers
 from rest_framework.permissions import AllowAny
 
@@ -41,6 +42,11 @@ router.register(
     prefix="my-competitions-current",
     viewset=views.MyCurrentCompetitionViewSet,
     base_name="my-competitions-current"
+)
+router.register(
+    prefix="my-devices",
+    viewset=FCMDeviceAuthorizedViewSet,
+    base_name="my-devices"
 )
 router.register(
     prefix="my-tags",

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -12,6 +12,9 @@ import logging
 
 from django.conf import settings
 from django_filters.rest_framework import DjangoFilterBackend
+import django_gamification.models
+import fcm_django.models
+from fcm_django.api.rest_framework import FCMDeviceSerializer
 from rest_framework.decorators import action
 from rest_framework import mixins
 from rest_framework import viewsets
@@ -19,7 +22,6 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_gis.pagination import GeoJsonPagination
-import django_gamification.models
 
 from keycloakauth import utils
 from keycloakauth.keycloakadmin import get_manager
@@ -452,6 +454,17 @@ class MyCompetitionWonViewSet(viewsets.ReadOnlyModelViewSet):
         context = super().get_serializer_context()
         context.update(user=self.request.user)
         return context
+
+
+class MyDeviceViewSet(viewsets.ModelViewSet):
+    serializer_class = FCMDeviceSerializer
+    required_permissions = (
+        "profiles.is_authenticated",
+    )
+
+    def get_queryset(self):
+        return fcm_django.models.FCMDevice.objects.filter(
+            user=self.request.user)
 
 
 def _update_group_memberships(user):

--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -87,6 +87,7 @@ INSTALLED_APPS = [
     "django_bootstrap_breadcrumbs",
     "avatar",
     "django_gamification",
+    "fcm_django",
     "base.apps.BaseConfig",
     "keycloakauth.apps.KeycloakauthConfig",
     "profiles.apps.ProfilesConfig",
@@ -283,6 +284,12 @@ MEDIA_ROOT = get_environment_variable(
     "DJANGO_MEDIA_ROOT",
     default_value=str(pathlib.Path(BASE_DIR).parent / "media"),
 )
+
+FCM_DJANGO_SETTINGS = {
+    "FCM_SERVER_KEY": get_environment_variable("FCM_API_KEY"),
+    "ONE_DEVICE_PER_USER": False,
+    "DELETE_INACTIVE_DEVICES": False
+}
 
 KEYCLOAK = {
     "base_url": get_environment_variable(


### PR DESCRIPTION
This PR adds support for [fcm_django], a django app that integrates with Google Firebase Cloud Messaging. It adds a new DB model for managing a user's devices. It also features a python API for sending notifications (however, since we'll be sending the messages mainly from the smb-backend project, we'll likely not use this much.)

In addition, this PR adds the following endpoints for managing devices:

-  `/api/my-devices/` - supports `GET` and `POST`, for listing and adding new devices
-  `/api/my-devices/{device-id}` - supports `GET`, `PUT`, `PATCH` and `DELETE` for listing and editing devices

Creating a new device:
```
POST /api/my-devices/
{
  "name": "device1",
  "registration_id": "123456",  # device's FCM registration token
  "device_id": "abcde1234",  # unique device identifier
  "type": "android"  # or "ios" or "web"
}
```

[fcm_django]: https://github.com/xtrinch/fcm-django