### PR TITLE
change fcm server key setting name

### DIFF
--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -286,7 +286,7 @@ MEDIA_ROOT = get_environment_variable(
 )
 
 FCM_DJANGO_SETTINGS = {
-    "FCM_SERVER_KEY": get_environment_variable("FCM_API_KEY"),
+    "FCM_SERVER_KEY": get_environment_variable("FCM_SERVER_KEY"),
     "ONE_DEVICE_PER_USER": False,
     "DELETE_INACTIVE_DEVICES": False
 }


### PR DESCRIPTION
This PR makes a small change to the FCM settings. The server key setting is now called `FCM_SERVER_KEY` in order to be consistent with fcm_django