### PR TITLE
Allow reusing same registration_id when registering a device again

### DIFF
--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -15,6 +15,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 import django_gamification.models
 import fcm_django.models
 from fcm_django.api.rest_framework import FCMDeviceSerializer
+from fcm_django.api.rest_framework import DeviceViewSetMixin
 from rest_framework.decorators import action
 from rest_framework import mixins
 from rest_framework import viewsets
@@ -456,7 +457,7 @@ class MyCompetitionWonViewSet(viewsets.ReadOnlyModelViewSet):
         return context
 
 
-class MyDeviceViewSet(viewsets.ModelViewSet):
+class MyDeviceViewSet(DeviceViewSetMixin, viewsets.ModelViewSet):
     serializer_class = FCMDeviceSerializer
     required_permissions = (
         "profiles.is_authenticated",


### PR DESCRIPTION
This PR makes it possible to register the same device with multiple users.

We just inherit from the fcm_django `DeviceViewSetMixin` which has a check that any device is always updated to belong to the current user. 