### PR TITLE
fix segment serializers for invalid tracks

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -913,19 +913,34 @@ class SegmentSerializer(serializers.ModelSerializer):
         return obj.geom.geojson
 
     def get_emissions(self, obj):
-        serializer = EmissionSerializer(
-            instance=obj.emission, context=self.context)
-        return serializer.data
+        try:
+            emissions = obj.emission
+            serializer = EmissionSerializer(
+                instance=emissions, context=self.context)
+            result = serializer.data
+        except tracks.models.Emission.DoesNotExist:
+            result = None
+        return result
 
     def get_costs(self, obj):
-        serializer = CostSerializer(
-            instance=obj.cost, context=self.context)
-        return serializer.data
+        try:
+            costs = obj.cost
+            serializer = CostSerializer(
+                instance=costs, context=self.context)
+            result = serializer.data
+        except tracks.models.Cost.DoesNotExist:
+            result = None
+        return result
 
     def get_health(self, obj):
-        serializer = HealthSerializer(
-            instance=obj.health, context=self.context)
-        return serializer.data
+        try:
+            health = obj.health
+            serializer = HealthSerializer(
+                instance=health, context=self.context)
+            result = serializer.data
+        except tracks.models.Health.DoesNotExist:
+            result = None
+        return result
 
     class Meta:
         model = tracks.models.Segment


### PR DESCRIPTION
Invalid tracks do not get the emissions, costs or health calculations done. As such the corresponding models are not created. This was causing errors when trying to access the detail view of an invalid track.

This PR fixes that error by guarding the emissions, costs, and health representations with appropriate `try..except` blocks