### PR TITLE
fix create badges management command bug

### DIFF
--- a/smbportal/badges/management/commands/createbadgedefinitions.py
+++ b/smbportal/badges/management/commands/createbadgedefinitions.py
@@ -98,7 +98,8 @@ def award_new_user_badges():
 def update_all_badges():
     for track in tm.Track.objects.all():
         db_connection = connections["default"].connection
-        update_badges(track.pk, db_connection)
+        cursor = db_connection.cursor()
+        update_badges(track.pk, cursor)
 
 
 def sort_badge_definitions(items, regexp="(\d+)"):


### PR DESCRIPTION
This PR fixes a mismatch between the latest `smbbackend.updatebadges` API and the portal's management command