### PR TITLE
fix current competitions API endpoints bug

### DIFF
--- a/smbportal/api/serializers.py
+++ b/smbportal/api/serializers.py
@@ -1172,7 +1172,7 @@ class CompetitionRankingSerializer(serializers.BaseSerializer):
             "username": instance[0].username
         }
         result.update(
-            {criterium.value: score for criterium, score in criteria.items()})
+            {criterium: score for criterium, score in criteria.items()})
         return result
 
 

--- a/smbportal/api/views.py
+++ b/smbportal/api/views.py
@@ -398,7 +398,7 @@ class CompetitionViewSet(viewsets.ReadOnlyModelViewSet):
     )
 
     def get_serializer_class(self):
-        if self.action == "list":
+        if self.action in ["list", "current_competitions"]:
             result = serializers.CompetitionListSerializer
         else:
             result = serializers.CompetitionDetailSerializer


### PR DESCRIPTION
This PR fixes a couple of bugs in the current competitions API endpoints.

These were introduced when we made leaderboards frozen for closed competitions in a previous commit.