### PR TITLE
added admin section for managing bike observations

### DIFF
--- a/smbportal/vehiclemonitor/admin.py
+++ b/smbportal/vehiclemonitor/admin.py
@@ -1,0 +1,19 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+from django.contrib.admin import register
+from django.contrib.gis.admin import OSMGeoAdmin
+
+from . import models
+
+
+@register(models.BikeObservation)
+class BikeObservationAdmin(OSMGeoAdmin):
+    pass


### PR DESCRIPTION
This PR hooks up the `BikeObservation` model to the django admin, so that it may be more easily managed by portal staff