### PR TITLE
calculation of segment speed is more robust to ZeroDivisionErrors

### DIFF
--- a/smbportal/tracks/models.py
+++ b/smbportal/tracks/models.py
@@ -217,7 +217,7 @@ class Segment(gismodels.Model):
         """Return average speed in km/h"""
         length_km = self.get_length().km
         duration_hour = self.duration.seconds / 3600
-        return length_km / duration_hour
+        return length_km / duration_hour if duration_hour > 0 else 0
 
 
 class Emission(models.Model):


### PR DESCRIPTION
This PR implements a fix for a possible `ZeroDivisionError` that might arise when calculating segment speed from fake data (real data would not have segments with a duration of zero, as those are filtered out during ingestion)