### PR TITLE
increase image upload size to 5 MB

### DIFF
--- a/smbportal/base/settings/base.py
+++ b/smbportal/base/settings/base.py
@@ -365,7 +365,7 @@ UPDATE_USER_DATA = "keycloakauth.oidchooks.update_user_data"
 LOAD_USER_ROLES = "keycloakauth.oidchooks.load_user_roles"
 
 SMB_PORTAL = {
-    "max_upload_size_megabytes": 2,
+    "max_upload_size_megabytes": 5,
     "max_bikes_per_user": 5,
     "max_pictures_per_bike": 5,
     "num_latest_observations": 5,


### PR DESCRIPTION
This PR increases image upload size limit from 2 MB to 5 MB

fixes #132 