### PR TITLE
add collected point exporter to the dashboard

### DIFF
--- a/smbportal/dashboard/exporter.py
+++ b/smbportal/dashboard/exporter.py
@@ -67,6 +67,70 @@ def export_collected_points(collected_points, output_path: pathlib.Path,
             "timestamp", ogr.OFTString,
             _get_attribute_field, ("timestamp", str),
         ),
+        FieldDef(
+            "acceleration_x", ogr.OFTReal,
+            _get_attribute_field, ("accelerationx",),
+        ),
+        FieldDef(
+            "acceleration_y", ogr.OFTReal,
+            _get_attribute_field, ("accelerationy",),
+        ),
+        FieldDef(
+            "acceleration_z", ogr.OFTReal,
+            _get_attribute_field, ("accelerationz",),
+        ),
+        FieldDef(
+            "accuracy", ogr.OFTReal,
+            _get_attribute_field, ("accuracy",),
+        ),
+        FieldDef(
+            "battery_consumption_per_hour", ogr.OFTReal,
+            _get_attribute_field, ("batconsumptionperhour",),
+        ),
+        FieldDef(
+            "battery_level", ogr.OFTReal,
+            _get_attribute_field, ("batterylevel",),
+        ),
+        FieldDef(
+            "device_bearing", ogr.OFTReal,
+            _get_attribute_field, ("devicebearing",),
+        ),
+        FieldDef(
+            "device_pitch", ogr.OFTReal,
+            _get_attribute_field, ("devicepitch",),
+        ),
+        FieldDef(
+            "device_roll", ogr.OFTReal,
+            _get_attribute_field, ("deviceroll",),
+        ),
+        FieldDef(
+            "elevation", ogr.OFTReal,
+            _get_attribute_field, ("elevation",),
+        ),
+        FieldDef(
+            "gps_bearing", ogr.OFTReal,
+            _get_attribute_field, ("gps_bearing",),
+        ),
+        FieldDef(
+            "humidity", ogr.OFTReal,
+            _get_attribute_field, ("humidity",),
+        ),
+        FieldDef(
+            "lumen", ogr.OFTReal,
+            _get_attribute_field, ("lumen",),
+        ),
+        FieldDef(
+            "proximity", ogr.OFTReal,
+            _get_attribute_field, ("proximity",),
+        ),
+        FieldDef(
+            "speed", ogr.OFTReal,
+            _get_attribute_field, ("speed",),
+        ),
+        FieldDef(
+            "temperature", ogr.OFTReal,
+            _get_attribute_field, ("temperature",),
+        ),
 
     ]
     return _export_model_with_ogr(

--- a/smbportal/dashboard/exporter.py
+++ b/smbportal/dashboard/exporter.py
@@ -35,6 +35,46 @@ FieldDef = namedtuple("FieldDef", [
 ])
 
 
+def export_collected_points(collected_points, output_path: pathlib.Path,
+                            driver_name="CSV"):
+    geom_attribute_name = "the_geom"
+    fields = [
+        FieldDef(
+            "id", ogr.OFTInteger,
+            _get_attribute_field, ("id",),
+        ),
+        FieldDef(
+            "vehicle_type", ogr.OFTString,
+            _get_attribute_field, ("vehicle_type",),
+        ),
+        FieldDef(
+            "track", ogr.OFTInteger,
+            _get_attribute_field, ("track_id",),
+        ),
+        FieldDef(
+            "longitude", ogr.OFTReal,
+            get_coordinate, ("longitude", geom_attribute_name),
+        ),
+        FieldDef(
+            "latitude", ogr.OFTReal,
+            get_coordinate, ("latitude", geom_attribute_name),
+        ),
+        FieldDef(
+            "sessionid", ogr.OFTString,
+            _get_attribute_field, ("sessionid", str),
+        ),
+        FieldDef(
+            "timestamp", ogr.OFTString,
+            _get_attribute_field, ("timestamp", str),
+        ),
+
+    ]
+    return _export_model_with_ogr(
+        collected_points, output_path, fields, driver_name,
+        geom_attribute_name=geom_attribute_name
+    )
+
+
 def export_segments(segments, output_path: pathlib.Path,
                     driver_name="ESRI Shapefile"):
     """Export segments with OGR"""

--- a/smbportal/dashboard/forms.py
+++ b/smbportal/dashboard/forms.py
@@ -11,8 +11,51 @@
 
 from django import forms
 from django.utils.translation import gettext as _
+from smbbackend._constants import VehicleType
 
 from vehicles.models import Bike
+from tracks.models import Track
+
+
+class CollectedPointDownloadForm(forms.Form):
+    start_date = forms.DateTimeField(
+        label=_("Start date"),
+        required=False,
+        widget=forms.DateTimeInput(
+            attrs={
+                "class": "date_time_picker"
+            }
+        )
+    )
+    end_date = forms.DateTimeField(
+        label=_("End date"),
+        required=False,
+        widget=forms.DateTimeInput(
+            attrs={
+                "class": "date_time_picker"
+            }
+        )
+    )
+    vehicle_types = forms.MultipleChoiceField(
+        label=_("Vehicle types"),
+        required=False,
+        choices=((k, k) for k in VehicleType.__members__.keys()),
+        widget=forms.SelectMultiple(
+            attrs={
+                "class": "select_2 select_2_multiple"
+            }
+        )
+    )
+    tracks = forms.ModelMultipleChoiceField(
+        label=_("Bikes"),
+        required=False,
+        queryset=Track.objects.all(),
+        widget=forms.SelectMultiple(
+            attrs={
+                "class": "select_2 select_2_multiple"
+            }
+        )
+    )
 
 
 class SegmentDownloadForm(forms.Form):

--- a/smbportal/templates/dashboard/analyst_index.html
+++ b/smbportal/templates/dashboard/analyst_index.html
@@ -21,6 +21,17 @@
         </div>
     </div>
     <div class="card margin-bottom-2x">
+        <div class="card-header"><h6>{% trans 'Track Points' %}</h6></div>
+        <div class="card-body">
+            <p>{% blocktrans %} Download track point data {% endblocktrans %}</p>
+            <form method="post">
+                {% csrf_token %}
+                {{ points_form|crispy }}
+                <input type="submit" name="{{ points_form.prefix }}-submit" value="{% trans 'Download' %}" class="btn btn-primary">
+            </form>
+        </div>
+    </div>
+    <div class="card margin-bottom-2x">
         <div class="card-header"><h6>{% trans 'Bike observations' %}</h6></div>
         <div class="card-body">
             {% blocktrans %}Download bike observations data{% endblocktrans %}


### PR DESCRIPTION
This PR adds a new section on the privileged user dashboard that allows downloading user's collected points.
Implementation follows a similar pattern as for other downloadable data. Date is returned in CSV format.