### PR TITLE
add owner-related fields to downloadable segments shapefile

### DIFF
--- a/smbportal/dashboard/urls.py
+++ b/smbportal/dashboard/urls.py
@@ -19,14 +19,4 @@ urlpatterns = [
         view=views.dashboard_downloads,
         name="index"
     ),
-    # path(
-    #     route="download-segments",
-    #     view=views.download_segments,
-    #     name="download-segments"
-    # ),
-    # path(
-    #     route="download-observations",
-    #     view=views.download_observations,
-    #     name="download-observations"
-    # ),
 ]


### PR DESCRIPTION
This PR adds the following user-related fields to each feature of the shapefile that the analyst users can download from the portal:

- `first_name`
- `last_name`
- `email`

Furthermore, the `anonymized_user` field (which had an anonymized reference to the user) has been removed.

fixes #188 