### PR TITLE
make competition.criteria and competition.age_groups admin friendlier

### DIFF
--- a/smbportal/base/fields.py
+++ b/smbportal/base/fields.py
@@ -1,0 +1,33 @@
+#########################################################################
+#
+# Copyright 2019, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+"""Custom fields for smb-portal"""
+
+from django import forms
+from django.contrib.postgres.fields import ArrayField
+
+from .widgets import ArrayFieldSelectMultipleWidget
+
+
+class ChoiceArrayField(ArrayField):
+
+    def formfield(self, **kwargs):
+        defaults = {
+            "form_class": forms.TypedMultipleChoiceField,
+            "choices": self.base_field.choices,
+            "coerce": self.base_field.to_python,
+            "widget": ArrayFieldSelectMultipleWidget,
+        }
+        defaults.update(kwargs)
+        # here we are calling ``formfield()`` of the ancestor class of
+        # ``ArrayField``, i.e. we do not call ``ÀrrayField.formfield`` at all.
+        # More info at:
+        # https://gist.github.com/danni/f55c4ce19598b2b345ef#gistcomment-2041847
+        return super(ArrayField, self).formfield(**defaults)

--- a/smbportal/base/widgets.py
+++ b/smbportal/base/widgets.py
@@ -1,6 +1,6 @@
 #########################################################################
 #
-# Copyright 2018, GeoSolutions Sas.
+# Copyright 2019, GeoSolutions Sas.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -10,6 +10,7 @@
 
 """Custom widgets for smb-portal"""
 
+from django.forms import SelectMultiple
 from django.contrib.gis.forms.widgets import OSMWidget
 
 
@@ -22,3 +23,9 @@ class SmbOsmWidget(OSMWidget):
         # - the template is responsible for loading the openlayers css and js
         #   assets
         extend = False
+
+
+class ArrayFieldSelectMultipleWidget(SelectMultiple):
+
+    def value_omitted_from_data(self, data, files, name):
+        return False

--- a/smbportal/prizes/models.py
+++ b/smbportal/prizes/models.py
@@ -22,6 +22,7 @@ from django.utils.translation import ugettext_lazy as _
 from smbbackend import calculateprizes
 import pytz
 
+from base.fields import ChoiceArrayField
 from profiles.models import EndUserProfile
 
 logger = logging.getLogger(__name__)
@@ -168,7 +169,7 @@ class Competition(models.Model):
         verbose_name=_("description"),
         blank=True
     )
-    age_groups = ArrayField(
+    age_groups = ChoiceArrayField(
         base_field=models.CharField(
             max_length=10,
             choices=[
@@ -192,6 +193,7 @@ class Competition(models.Model):
         ),
         size=4,
         verbose_name=_("age group"),
+        default=list
     )
     start_date = models.DateTimeField(
         verbose_name=_("start date"),
@@ -201,26 +203,29 @@ class Competition(models.Model):
         verbose_name=_("end date"),
         help_text=_("Date when the competition ended"),
     )
-    criteria = ArrayField(
+    criteria = ChoiceArrayField(
         base_field=models.CharField(
             max_length=100,
             choices=[
-                (CRITERIUM_SAVED_CO2_EMISSIONS, _("saved CO2 emissions")),
+                (CRITERIUM_SAVED_SO2_EMISSIONS, _("saved SO2 emissions")),
                 (CRITERIUM_SAVED_NOX_EMISSIONS, _("saved NOx emissions")),
                 (CRITERIUM_SAVED_CO2_EMISSIONS, _("saved CO2 emissions")),
                 (CRITERIUM_SAVED_CO_EMISSIONS, _("saved CO emissions")),
                 (CRITERIUM_SAVED_PM10_EMISSIONS, _("saved PM10 emissions")),
-                (CRITERIUM_CONSUMED_CALORIES, _("consumed calories")),
-                (CRITERIUM_BIKE_USAGE_FREQUENCY, _("bike usage frequency")),
-                (
-                    CRITERIUM_PUBLIC_TRANSPORT_USAGE_FREQUENCY,
-                    _("public transport usage frequency")
-                ),
-                (CRITERIUM_BIKE_DISTANCE, _("bike distance")),
-                (
-                    CRITERIUM_SUSTAINABLE_MEANS_DISTANCE,
-                    _("sustainable means distance")
-                ),
+                # NOTE: The following are commented out because the backend
+                # does not know how to score them yet
+                #
+                # (CRITERIUM_CONSUMED_CALORIES, _("consumed calories")),
+                # (CRITERIUM_BIKE_USAGE_FREQUENCY, _("bike usage frequency")),
+                # (
+                #     CRITERIUM_PUBLIC_TRANSPORT_USAGE_FREQUENCY,
+                #     _("public transport usage frequency")
+                # ),
+                # (CRITERIUM_BIKE_DISTANCE, _("bike distance")),
+                # (
+                #     CRITERIUM_SUSTAINABLE_MEANS_DISTANCE,
+                #     _("sustainable means distance")
+                # ),
             ]
         ),
         verbose_name=_("criteria"),


### PR DESCRIPTION
This PR adds a customized django field for the storage of postgres `ARRAY`s that allows the usage of `choices`.

This new Array-based field is then applied to `Competition.criteria` and `Competition.age_groups` in order to present a friendlier GUI in the django admin.

The following screenshot shows these two fields:

![custom_array_field_with_squares](https://user-images.githubusercontent.com/732010/62699837-56b09b80-b9d8-11e9-93da-1519090e457a.png)

fixes #201