### PR TITLE
fix competition participant details not showing up on moderation email

### DIFF
--- a/smbportal/keycloakauth/oidchooks.py
+++ b/smbportal/keycloakauth/oidchooks.py
@@ -45,9 +45,10 @@ def update_user_data(user, token):
 
 
 def update_user_details(user, token):
-    email = token.get("email")
-    if email is not None:
-        user.email = email
+    user.first_name = token.get("given_name", user.first_name)
+    user.last_name = token.get("family_name", user.last_name)
+    user.username = token.get("preferred_username", user.username)
+    user.email = token.get("email", user.email)
     user.save()
 
 

--- a/smbportal/templates/prizes/mail/pending_moderation_request_message.txt
+++ b/smbportal/templates/prizes/mail/pending_moderation_request_message.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans %}User {{ participant.user.email }} wants to register for competition {{ participant.competition }}.
+{% load i18n %}{% blocktrans with username=participant.user.username competition_name=participant.competition.name %}User {{ username }} wants to register for competition {{ competition_name }}.
 
 For moderating this request, please visit {{ site_name }} and log in with your credentials
 

--- a/smbportal/templates/prizes/mail/request_moderated_message.txt
+++ b/smbportal/templates/prizes/mail/request_moderated_message.txt
@@ -6,7 +6,7 @@ Your request for participating in the competition {{ competition_name }} has bee
 {% blocktrans with end_date=participant.competition.end_date %}
 Your tracks and emission savings will now be ranked with other participants of the competition!
 
-This competition will close on {{ participant.competition.end_date }}.
+This competition will close on {{ end_date }}.
 {% endblocktrans %}
 {% else %}
 {% blocktrans %}


### PR DESCRIPTION
This PR fixes the competition moderation email templates in order to show information regarding the current user.

The underlying problem was a misuse of django's `blocktrans` block, which requires aliasing complex variables in order for them to be available inside the block.

This PR also includes an update to the `oidchooks.update_user_details` function that is now updating a user's name fields (username, first_name, last_name) in addition to the email address from keycloak. This improves synchronization between django and Keycloak.

fixes #203
